### PR TITLE
EVA-795 Add default annotation version to database collection

### DIFF
--- a/database-migration/src/main/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariant.java
+++ b/database-migration/src/main/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariant.java
@@ -26,6 +26,7 @@ import com.mongodb.client.model.IndexOptions;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.slf4j.Logger;
@@ -360,6 +361,7 @@ public class ExtractAnnotationFromVariant {
         String id = databaseParameters.getVepVersion() + "_" + databaseParameters.getVepCacheVersion();
         Document defaultVersionDocument = new Document(ID_FIELD, id);
         Document setDefaultToTrue = new Document("$set", new Document(DEFAULT_VERSION_FIELD, true));
-        annotationMetadataCollection.updateOne(defaultVersionDocument, setDefaultToTrue);
+        UpdateResult updateResult = annotationMetadataCollection.updateOne(defaultVersionDocument, setDefaultToTrue);
+        Assert.state(updateResult.getModifiedCount() == 1);
     }
 }

--- a/database-migration/src/main/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariant.java
+++ b/database-migration/src/main/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariant.java
@@ -354,9 +354,9 @@ public class ExtractAnnotationFromVariant {
                 databaseParameters.getDbCollectionsAnnotationMetadataName());
         logger.info("6) add default annotation version to collection {} ", annotationMetadataCollection.getNamespace());
 
-        Document all = new Document();
-        Document versionIsNotTheDefaultOne = new Document("$set", new Document(DEFAULT_VERSION_FIELD, false));
-        annotationMetadataCollection.updateMany(all, versionIsNotTheDefaultOne);
+        Document allVersions = new Document();
+        Document setDefaultToFalse = new Document("$set", new Document(DEFAULT_VERSION_FIELD, false));
+        annotationMetadataCollection.updateMany(allVersions, setDefaultToFalse);
 
         String id = databaseParameters.getVepVersion() + "_" + databaseParameters.getVepCacheVersion();
         Document defaultVersionDocument = new Document(ID_FIELD, id);

--- a/database-migration/src/test/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariantTest.java
+++ b/database-migration/src/test/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariantTest.java
@@ -36,6 +36,7 @@ import java.util.TreeSet;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static uk.ac.ebi.eva.dbmigration.mongodb.ExtractAnnotationFromVariant.ANNOT_FIELD;
 import static uk.ac.ebi.eva.dbmigration.mongodb.ExtractAnnotationFromVariant.CACHE_VERSION_FIELD;
@@ -447,9 +448,9 @@ public class ExtractAnnotationFromVariantTest {
 
         for (Document document : collection.find()) {
             if (document.get(VEP_VERSION_FIELD).equals(VEP_VERSION)) {
-                assertEquals(true, document.get(DEFAULT_VERSION_FIELD));
+                assertTrue((Boolean) document.get(DEFAULT_VERSION_FIELD));
             } else {
-                assertEquals(false, document.get(DEFAULT_VERSION_FIELD));
+                assertFalse((Boolean) document.get(DEFAULT_VERSION_FIELD));
             }
         }
     }

--- a/database-migration/src/test/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariantTest.java
+++ b/database-migration/src/test/java/uk/ac/ebi/eva/dbmigration/mongodb/ExtractAnnotationFromVariantTest.java
@@ -454,6 +454,33 @@ public class ExtractAnnotationFromVariantTest {
         }
     }
 
+    @Test
+    public void testDefaultAnnotationVersionNotFound() throws Exception {
+        String dbName = "defaultAnnotation";
+
+        Properties properties = new Properties();
+        properties.put(DatabaseParameters.VEP_VERSION, VEP_VERSION);
+        properties.put(DatabaseParameters.VEP_CACHE_VERSION, CACHE_VERSION);
+        properties.put(DatabaseParameters.DB_NAME, dbName);
+        properties.put(DatabaseParameters.DB_COLLECTIONS_VARIANTS_NAME, VARIANT_COLLECTION_NAME);
+        properties.put(DatabaseParameters.DB_COLLECTIONS_ANNOTATIONS_NAME, ANNOTATION_COLLECTION_NAME);
+        properties.put(DatabaseParameters.DB_COLLECTIONS_ANNOTATION_METADATA_NAME, ANNOTATION_METADATA_COLLECTION_NAME);
+        properties.put(DatabaseParameters.DB_READ_PREFERENCE, READ_PREFERENCE);
+        DatabaseParameters databaseParameters = new DatabaseParameters();
+        databaseParameters.load(properties);
+        ExtractAnnotationFromVariant.setDatabaseParameters(databaseParameters);
+
+        MongoDatabase mongoDatabase = new Fongo("testServer").getDatabase(dbName);
+        MongoCollection<Document> collection = mongoDatabase.getCollection(ANNOTATION_METADATA_COLLECTION_NAME);
+
+        collection.insertOne(buildAnnotationMetadataDocument("79", "78"));
+        collection.insertOne(buildAnnotationMetadataDocument("80", "82"));
+        collection.insertOne(buildAnnotationMetadataDocument("98", "99"));
+
+        exception.expect(IllegalStateException.class);
+        extractAnnotationFromVariant.addDefaultVersion(mongoDatabase);
+    }
+
     private Document buildAnnotationMetadataDocument(String vepVersion, String vepCacheVersion) {
         return new Document(ID_FIELD, vepVersion + "_" + vepCacheVersion)
                 .append(VEP_VERSION_FIELD, vepVersion)


### PR DESCRIPTION
Add a migration changeset that adds a "is_default" flag to every document in annotationMetadata, and set only one to "true". which version is set as default is the same that is added in the other steps, i.e. the attributes `vep.version=78` and `vep.cache.version=78`