### PR TITLE
EVA-496 Filter INFO fields when merging headers

### DIFF
--- a/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VariantExporter.java
+++ b/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VariantExporter.java
@@ -178,11 +178,8 @@ public class VariantExporter {
             Object headerObject = source.getMetadata().get(DBObjectToVariantSourceConverter.HEADER_FIELD);
 
             if (headerObject instanceof String) {
-                VCFCodec vcfCodec = new VCFCodec();
-                ByteArrayInputStream bufferedInputStream = new ByteArrayInputStream(((String) headerObject).getBytes());
-                LineIterator sourceFromStream = vcfCodec.makeSourceFromStream(bufferedInputStream);
-                FeatureCodecHeader featureCodecHeader = vcfCodec.readHeader(sourceFromStream);
-                VCFHeader headerValue = (VCFHeader) featureCodecHeader.getHeaderValue();
+                VCFHeader headerValue = getVcfHeaderFilteringInfoLines((String) headerObject);
+
                 headers.put(source.getStudyId(), headerValue);
             } else {
                 throw new IllegalArgumentException("File headers not available for study " + source.getStudyId());
@@ -190,6 +187,14 @@ public class VariantExporter {
         }
 
         return headers;
+    }
+
+    private VCFHeader getVcfHeaderFilteringInfoLines(String headerObject) throws IOException {
+        VCFCodec vcfCodec = new VCFCodec();
+        ByteArrayInputStream bufferedInputStream = new ByteArrayInputStream(headerObject.getBytes());
+        LineIterator filteringLineIterator = new VcfHeaderFilteringLineIterator(bufferedInputStream, "INFO");
+        FeatureCodecHeader featureCodecHeader = vcfCodec.readHeader(filteringLineIterator);
+        return (VCFHeader) featureCodecHeader.getHeaderValue();
     }
 
     public VCFHeader getMergedVcfHeader(List<VariantSource> sources) throws IOException {

--- a/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIterator.java
+++ b/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIterator.java
@@ -1,0 +1,36 @@
+package uk.ac.ebi.eva.vcfdump;
+
+import htsjdk.tribble.readers.LineIteratorImpl;
+import htsjdk.tribble.readers.LineReaderUtil;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class VcfHeaderFilteringLineIterator extends LineIteratorImpl {
+
+    private Set<String> fieldsToExclude;
+
+    public VcfHeaderFilteringLineIterator(InputStream inputStream, String ... fieldsToExclude) {
+        super(LineReaderUtil.fromBufferedStream(inputStream));
+        this.fieldsToExclude =
+                Arrays.stream(fieldsToExclude).map(field -> "##" + field + "=").collect(Collectors.toSet());
+    }
+
+    /**
+     * Return the next header line, excluding the ones starting with any of the fields to filter
+     * @return The following not filtered header line
+     */
+    protected String advance() {
+        String line = super.advance();
+        while (line != null && excludeLine(line)) {
+            line = super.advance();
+        }
+        return line;
+    }
+
+    private boolean excludeLine(String line) {
+        return fieldsToExclude.stream().anyMatch(field -> line.startsWith(field));
+    }
+}

--- a/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIterator.java
+++ b/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIterator.java
@@ -42,13 +42,13 @@ public class VcfHeaderFilteringLineIterator extends LineIteratorImpl {
      */
     protected String advance() {
         String line = super.advance();
-        while (line != null && excludeLine(line)) {
+        while (line != null && shouldExcludeLine(line)) {
             line = super.advance();
         }
         return line;
     }
 
-    private boolean excludeLine(String line) {
-        return fieldsToExclude.stream().anyMatch(field -> line.startsWith(field));
+    private boolean shouldExcludeLine(String line) {
+        return fieldsToExclude.stream().anyMatch(line::startsWith);
     }
 }

--- a/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIterator.java
+++ b/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIterator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.vcfdump;
 
 import htsjdk.tribble.readers.LineIteratorImpl;
@@ -8,6 +23,9 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Implementation of HTSJDK LineIterator that can filter out VCF Header fields lines when iterating
+ */
 public class VcfHeaderFilteringLineIterator extends LineIteratorImpl {
 
     private Set<String> fieldsToExclude;

--- a/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VariantExporterTest.java
+++ b/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VariantExporterTest.java
@@ -123,7 +123,7 @@ public class VariantExporterTest {
         String study7Id = "7";
         List<String> studies = Collections.singletonList(study7Id);
         List<VariantSource> sources =
-                variantExporter.getSources(variantSourceDBAdaptor, studies, Collections.EMPTY_LIST);
+                variantExporter.getSources(variantSourceDBAdaptor, studies, Collections.emptyList());
         assertEquals(1, sources.size());
         VariantSource file = sources.get(0);
 
@@ -138,7 +138,7 @@ public class VariantExporterTest {
         String study8Id = "8";
         List<String> studies = Arrays.asList(study7Id, study8Id);
         List<VariantSource> sources = variantExporter
-                .getSources(variantSourceDBAdaptor, studies, Collections.EMPTY_LIST);
+                .getSources(variantSourceDBAdaptor, studies, Collections.emptyList());
         assertEquals(2, sources.size());
         VariantSource file = sources.stream().filter(s -> s.getStudyId().equals(study7Id)).findFirst().get();
         assertEquals(study7Id, file.getStudyId());
@@ -155,7 +155,7 @@ public class VariantExporterTest {
         // one study with two files, without asking for any particular file
         List<String> sheepStudy = Collections.singletonList(TestDBRule.SHEEP_STUDY_ID);
         List<VariantSource> sources = variantExporter
-                .getSources(sheepVariantSourceDBAdaptor, sheepStudy, Collections.EMPTY_LIST);
+                .getSources(sheepVariantSourceDBAdaptor, sheepStudy, Collections.emptyList());
         assertEquals(2, sources.size());
         boolean correctStudyId = sources.stream()
                                         .allMatch(s -> s.getStudyId().equals(TestDBRule.SHEEP_STUDY_ID));
@@ -172,7 +172,7 @@ public class VariantExporterTest {
         List<String> sheepStudy = Collections.singletonList(TestDBRule.SHEEP_STUDY_ID);
         List<VariantSource> sources = variantExporter.getSources(sheepVariantSourceDBAdaptor, sheepStudy,
                                                                  Arrays.asList(TestDBRule.SHEEP_FILE_1_ID,
-                                                                         TestDBRule.SHEEP_FILE_2_ID));
+                                                                               TestDBRule.SHEEP_FILE_2_ID));
         assertEquals(2, sources.size());
         boolean correctStudyId = sources.stream()
                                         .allMatch(s -> s.getStudyId().equals(TestDBRule.SHEEP_STUDY_ID));
@@ -203,7 +203,7 @@ public class VariantExporterTest {
     public void getSourcesEmptyStudiesFilter() {
         // empty study filter
         List<VariantSource> sources = variantExporter
-                .getSources(variantSourceDBAdaptor, Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+                .getSources(variantSourceDBAdaptor, Collections.emptyList(), Collections.emptyList());
         assertEquals(0, sources.size());
     }
 
@@ -212,7 +212,7 @@ public class VariantExporterTest {
         VariantExporter variantExporter = new VariantExporter();
         // The study with id "2" is not in database
         List<String> study = Collections.singletonList("2");
-        variantExporter.getSources(variantSourceDBAdaptor, study, Collections.EMPTY_LIST);
+        variantExporter.getSources(variantSourceDBAdaptor, study, Collections.emptyList());
     }
 
     @Test
@@ -259,7 +259,7 @@ public class VariantExporterTest {
         String study8Id = "8";
         List<String> studies = Arrays.asList(study7Id, study8Id);
         List<VariantSource> sources =
-                variantExporter.getSources(variantSourceDBAdaptor, studies, Collections.EMPTY_LIST);
+                variantExporter.getSources(variantSourceDBAdaptor, studies, Collections.emptyList());
 
         Map<String, VCFHeader> headers = variantExporter.getVcfHeaders(sources);
         VCFHeader header = headers.get(study7Id);
@@ -275,7 +275,7 @@ public class VariantExporterTest {
         VariantExporter variantExporter = new VariantExporter();
         List<String> cowStudyIds = Arrays.asList("PRJEB6119", "PRJEB7061");
         List<VariantSource> cowSources =
-                variantExporter.getSources(cowVariantSourceDBAdaptor, cowStudyIds, Collections.EMPTY_LIST);
+                variantExporter.getSources(cowVariantSourceDBAdaptor, cowStudyIds, Collections.emptyList());
         VCFHeader header = variantExporter.getMergedVcfHeader(cowSources);
 
         // assert
@@ -291,7 +291,7 @@ public class VariantExporterTest {
         String region = "20:61000-69000";
         QueryOptions query = new QueryOptions();
         List<VariantContext> exportedVariants = exportAndCheck(variantSourceDBAdaptor, variantDBAdaptor, query, studies,
-                                                               Collections.EMPTY_LIST, region);
+                                                               Collections.emptyList(), region);
         checkExportedVariants(variantDBAdaptor, query, exportedVariants);
     }
 
@@ -301,7 +301,7 @@ public class VariantExporterTest {
         String region = "20:61000-69000";
         QueryOptions query = new QueryOptions();
         List<VariantContext> exportedVariants = exportAndCheck(variantSourceDBAdaptor, variantDBAdaptor, query, studies,
-                                                               Collections.EMPTY_LIST, region);
+                                                               Collections.emptyList(), region);
         checkExportedVariants(variantDBAdaptor, query, exportedVariants);
     }
 
@@ -310,7 +310,7 @@ public class VariantExporterTest {
         List<String> studies = Collections.singletonList("PRJEB6119");
         String region = "21:820000-830000";
         QueryOptions query = new QueryOptions();
-        exportAndCheck(cowVariantSourceDBAdaptor, cowVariantDBAdaptor, query, studies, Collections.EMPTY_LIST, region,
+        exportAndCheck(cowVariantSourceDBAdaptor, cowVariantDBAdaptor, query, studies, Collections.emptyList(), region,
                        4);
     }
 
@@ -329,7 +329,8 @@ public class VariantExporterTest {
         assertTrue(samplesNumberCorrect);
     }
 
-    // TODO: this test is not going to work as expected because ID and Region are an OR filter. Add annotation data to the test data
+    // TODO: this test is not going to work as expected because ID and Region are an OR filter. Add annotation data
+    // to the test data
     //       and write a test filtering by annotation
 //    @Test
 //    public void textExportWithFilter() {
@@ -360,7 +361,8 @@ public class VariantExporterTest {
 
         VariantDBIterator iterator = variantDBAdaptor.iterator(query);
 
-        // we need to call 'getSources' before 'export' because it check if there are sample name conflicts and initialize some dependencies
+        // we need to call 'getSources' before 'export' because it check if there are sample name conflicts and
+        // initialize some dependencies
         variantExporter.getSources(variantSourceDBAdaptor, studies, files);
         List<VariantContext> exportedVariants = variantExporter.export(iterator, new Region(region));
 

--- a/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VariantExporterTest.java
+++ b/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VariantExporterTest.java
@@ -280,7 +280,8 @@ public class VariantExporterTest {
 
         // assert
         assertEquals(1, header.getContigLines().size());
-        assertEquals(4, header.getInfoHeaderLines().size());
+        // the INFO field header lines are being filtered out
+        assertEquals(0, header.getInfoHeaderLines().size());
         assertEquals(2, header.getFormatHeaderLines().size());
     }
 

--- a/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIteratorTest.java
+++ b/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIteratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package uk.ac.ebi.eva.vcfdump;
 
 import org.junit.Before;

--- a/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIteratorTest.java
+++ b/vcf-dumper/vcf-dumper-lib/src/test/java/uk/ac/ebi/eva/vcfdump/VcfHeaderFilteringLineIteratorTest.java
@@ -1,0 +1,101 @@
+package uk.ac.ebi.eva.vcfdump;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class VcfHeaderFilteringLineIteratorTest {
+
+    public static final int HEADER_LINES = 18;
+
+    private InputStream inputStream;
+
+    @Before
+    public void setUp() throws Exception {
+        inputStream = this.getClass().getResourceAsStream("/vcfTestHeader.vcf");
+    }
+
+    @Test
+    public void iteratingWithoutFiltersWillReturnAllLines() {
+        VcfHeaderFilteringLineIterator iterator = new VcfHeaderFilteringLineIterator(inputStream);
+
+        assertEquals(HEADER_LINES, countLinesUsingIterator(iterator));
+    }
+
+    @Test
+    public void iterateExcludingNonExistingFieldsWillReturnAllLines() {
+        VcfHeaderFilteringLineIterator iterator = new VcfHeaderFilteringLineIterator(inputStream, "NotExistingField1",
+                                                                                     "NotExistingField2");
+
+        assertEquals(HEADER_LINES, countLinesUsingIterator(iterator));
+    }
+
+    @Test
+    public void iterateOverHeaderExcludingInfoFields() {
+        VcfHeaderFilteringLineIterator iterator = new VcfHeaderFilteringLineIterator(inputStream, "INFO");
+
+        assertIteratorReturnHeaderLine(iterator, "##fileformat=VCFv4.2");
+        assertIteratorReturnHeaderLine(iterator, "##ALT=<ID=CNV:124,Description=\"Copy number allele: 124 copies\">");
+        assertIteratorReturnHeaderLine(iterator, "##ALT=<ID=DEL,Description=\"Deletion\">");
+        assertIteratorReturnHeaderLine(iterator, "##FILTER=<ID=PASS,Description=\"All filters passed\">");
+        assertIteratorReturnHeaderLine(iterator,
+                                       "##FORMAT=<ID=DS,Number=1,Type=Float,Description=\"Genotype dosage from " +
+                                               "MaCH/Thunder\">");
+        assertIteratorReturnHeaderLine(iterator,
+                                       "##FORMAT=<ID=GL,Number=.,Type=Float,Description=\"Genotype Likelihoods\">");
+        assertIteratorReturnHeaderLine(iterator, "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">");
+        assertIteratorReturnHeaderLine(iterator, "##FORMAT=<ID=PL,Number=G,Type=Integer,Description=\"Normalized, " +
+                "Phred-scaled likelihoods for genotypes as defined in the VCF specification\">");
+        assertIteratorReturnHeaderLine(iterator, "##contig=<ID=hs37d5,assembly=b37,length=35477943>");
+        assertIteratorReturnHeaderLine(iterator, "##fileDate=20150218");
+        assertIteratorReturnHeaderLine(iterator, "##reference=GRCh37");
+        assertIteratorReturnHeaderLine(iterator, "##source=1000GenomesPhase3Pipeline");
+        assertIteratorReturnHeaderLine(iterator,
+                                       "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tERZX00049_HG03976" +
+                                               "\tERZX00049_HG03977\tERZX00049_HG03978\tERZ015361_HG00381\tERZ015361_HG00382\tERZ015361_HG00383");
+
+        assertFalse(iterator.hasNext());
+
+    }
+
+    @Test
+    public void iterateOverHeaderExcludingInfoAndFormatFields() {
+        VcfHeaderFilteringLineIterator iterator = new VcfHeaderFilteringLineIterator(inputStream, "INFO", "FORMAT");
+
+        assertIteratorReturnHeaderLine(iterator, "##fileformat=VCFv4.2");
+        assertIteratorReturnHeaderLine(iterator, "##ALT=<ID=CNV:124,Description=\"Copy number allele: 124 copies\">");
+        assertIteratorReturnHeaderLine(iterator, "##ALT=<ID=DEL,Description=\"Deletion\">");
+        assertIteratorReturnHeaderLine(iterator, "##FILTER=<ID=PASS,Description=\"All filters passed\">");
+        assertIteratorReturnHeaderLine(iterator, "##contig=<ID=hs37d5,assembly=b37,length=35477943>");
+        assertIteratorReturnHeaderLine(iterator, "##fileDate=20150218");
+        assertIteratorReturnHeaderLine(iterator, "##reference=GRCh37");
+        assertIteratorReturnHeaderLine(iterator, "##source=1000GenomesPhase3Pipeline");
+        assertIteratorReturnHeaderLine(iterator,
+                                       "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tERZX00049_HG03976" +
+                                               "\tERZX00049_HG03977\tERZX00049_HG03978\tERZ015361_HG00381\tERZ015361_HG00382\tERZ015361_HG00383");
+
+        assertFalse(iterator.hasNext());
+
+    }
+
+    private void assertIteratorReturnHeaderLine(VcfHeaderFilteringLineIterator iterator, String expectedLine) {
+        assertTrue(iterator.hasNext());
+        String returnedLine = iterator.next();
+        assertEquals(expectedLine, returnedLine);
+    }
+
+    private int countLinesUsingIterator(Iterator iterator) {
+        int lines = 0;
+        while (iterator.hasNext()) {
+            iterator.next();
+            lines++;
+        }
+        return lines;
+    }
+}

--- a/vcf-dumper/vcf-dumper-lib/src/test/resources/vcfTestHeader.vcf
+++ b/vcf-dumper/vcf-dumper-lib/src/test/resources/vcfTestHeader.vcf
@@ -1,0 +1,18 @@
+##fileformat=VCFv4.2
+##ALT=<ID=CNV:124,Description="Copy number allele: 124 copies">
+##ALT=<ID=DEL,Description="Deletion">
+##FILTER=<ID=PASS,Description="All filters passed">
+##FORMAT=<ID=DS,Number=1,Type=Float,Description="Genotype dosage from MaCH/Thunder">
+##FORMAT=<ID=GL,Number=.,Type=Float,Description="Genotype Likelihoods">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele, ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/pilot_data/technical/reference/ancestral_alignments/README">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency, for each ALT allele, in the same order as listed">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="Normalized, Phred-scaled likelihoods for genotypes as defined in the VCF specification">
+##INFO=<ID=AMR_AF,Number=.,Type=Float,Description="Allele Frequency for samples from AMR based on AC/AN">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total Allele Count">
+##contig=<ID=hs37d5,assembly=b37,length=35477943>
+##fileDate=20150218
+##reference=GRCh37
+##source=1000GenomesPhase3Pipeline
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	ERZX00049_HG03976	ERZX00049_HG03977	ERZX00049_HG03978	ERZ015361_HG00381	ERZ015361_HG00382	ERZ015361_HG00383


### PR DESCRIPTION
If we dump variants from several studies, the headers for those studies are merged. In some cases, there are INFO fields with not compatible values in different studies. Those fields cannot be merged, and the HTSJDK VCF Header merger class throws an exception. 

To solve this issue, we have developed a VCF Header iterator that can filter out field types from the header (like INFO). By default, we will exclude the INFO fields, because they are not being written in the output VCF. 