### PR TITLE
EVA-926 Query the obsvariation table from the shared schema

### DIFF
--- a/dbsnp-importer/pom.xml
+++ b/dbsnp-importer/pom.xml
@@ -32,6 +32,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.hsqldb</groupId>
@@ -46,19 +51,9 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>uk.ac.ebi.eva</groupId>
             <artifactId>variation-commons-core</artifactId>
             <version>0.5-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-test</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -93,7 +93,7 @@ import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.S
         subsnp sub ON link.subsnp_id = sub.subsnp_id JOIN
         batch ON sub.batch_id = batch.batch_id JOIN
         b150_snphgvslink hgvs ON hgvs.snp_link = loc.snp_id JOIN
-        obsvariation ON obsvariation.var_id = sub.variation_id
+        dbsnp_shared.obsvariation ON obsvariation.var_id = sub.variation_id
     WHERE
         batch.batch_id = $batch
         AND ctg.group_term IN($assemblyTypes)
@@ -157,12 +157,12 @@ public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreField
         factoryBean.setFromClause(
                 "FROM " +
                         "b150_snpcontigloc loc JOIN " +
-                        "b150_contiginfo ctg ON ctg.ctg_id = loc.ctg_id JOIN " +
+                        "b150_contiginfo ctg ON ctg.contig_gi = loc.ctg_id JOIN " +
                         "snpsubsnplink link ON loc.snp_id = link.snp_id JOIN " +
                         "subsnp sub ON link.subsnp_id = sub.subsnp_id JOIN " +
                         "batch on sub.batch_id = batch.batch_id JOIN " +
                         "b150_snphgvslink hgvs ON hgvs.snp_link = loc.snp_id JOIN " +
-                        "obsvariation on obsvariation.var_id = sub.variation_id"
+                        "dbsnp_shared.obsvariation ON obsvariation.var_id = sub.variation_id"
         );
         factoryBean.setWhereClause(
                 "WHERE " +

--- a/dbsnp-importer/src/main/resources/application.properties
+++ b/dbsnp-importer/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.url=@eva.evapro.url@?currentSchema=@eva.dbsnp.schema@
+spring.datasource.username=@eva.evapro.username@
+spring.datasource.password=@eva.evapro.password@
+
+spring.jpa.generate-ddl=false

--- a/dbsnp-importer/src/test/resources/application.properties
+++ b/dbsnp-importer/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 spring.datasource.driver-class-name=org.hsqldb.jdbcDriver
-spring.datasource.url=jdbc:hsqldb:mem:db;DB_CLOSE_DELAY=-1
+spring.datasource.url=jdbc:hsqldb:mem:db;sql.syntax_pgs=true;DB_CLOSE_DELAY=-1
 spring.datasource.username=SA
 spring.datasource.password=
 
@@ -8,4 +8,3 @@ spring.datasource.password=
 spring.datasource.generate-unique-name=true
 
 spring.jpa.hibernate.ddl-auto=none
-sql.syntax_pgs=true

--- a/dbsnp-importer/src/test/resources/data.sql
+++ b/dbsnp-importer/src/test/resources/data.sql
@@ -155,10 +155,10 @@ INSERT INTO b150_snphgvslink VALUES (14708208,'NC_006091.4:g.40648870T>G','96674
 
 
 -- 'var_id','pattern','create_time','last_updated_time','univar_id','var_flag','pattern_left'
-INSERT INTO obsvariation VALUES (11,'T/G','2003-02-22 01:07:00','2003-07-17 14:33:00',25,NULL,'T/G');
-INSERT INTO obsvariation VALUES (13,'T/C','2003-02-22 01:07:00','2003-07-17 14:33:00',35,NULL,'T/C');
-INSERT INTO obsvariation VALUES (16,'T/A','2003-02-22 01:07:00','2003-07-17 14:33:00',23,NULL,'T/A');
-INSERT INTO obsvariation VALUES (20,'G/A','2003-02-22 01:07:00','2003-07-17 14:33:00',2,NULL,'G/A');
-INSERT INTO obsvariation VALUES (34,'-/G','2003-02-22 01:07:00','2003-07-17 14:33:00',15,NULL,'-/G');
-INSERT INTO obsvariation VALUES (11680,'TCGG/-','2003-04-16 09:16:00','2003-07-17 14:33:00',238,NULL,'TCGG/-');
-INSERT INTO obsvariation VALUES (13946,'TCAGG/-','2003-04-16 15:12:00','2003-07-17 14:33:00',570,NULL,'TCAGG/-');
+INSERT INTO dbsnp_shared.obsvariation VALUES (11,'T/G','2003-02-22 01:07:00','2003-07-17 14:33:00',25,NULL,'T/G');
+INSERT INTO dbsnp_shared.obsvariation VALUES (13,'T/C','2003-02-22 01:07:00','2003-07-17 14:33:00',35,NULL,'T/C');
+INSERT INTO dbsnp_shared.obsvariation VALUES (16,'T/A','2003-02-22 01:07:00','2003-07-17 14:33:00',23,NULL,'T/A');
+INSERT INTO dbsnp_shared.obsvariation VALUES (20,'G/A','2003-02-22 01:07:00','2003-07-17 14:33:00',2,NULL,'G/A');
+INSERT INTO dbsnp_shared.obsvariation VALUES (34,'-/G','2003-02-22 01:07:00','2003-07-17 14:33:00',15,NULL,'-/G');
+INSERT INTO dbsnp_shared.obsvariation VALUES (11680,'TCGG/-','2003-04-16 09:16:00','2003-07-17 14:33:00',238,NULL,'TCGG/-');
+INSERT INTO dbsnp_shared.obsvariation VALUES (13946,'TCAGG/-','2003-04-16 15:12:00','2003-07-17 14:33:00',570,NULL,'TCAGG/-');

--- a/dbsnp-importer/src/test/resources/schema.sql
+++ b/dbsnp-importer/src/test/resources/schema.sql
@@ -14,19 +14,7 @@ SET client_min_messages = warning;
 SET row_security = off;
 */
 
---
--- Name: dbsnp_chicken_9031; Type: SCHEMA; Schema: -; Owner: -
---
 
-CREATE SCHEMA dbsnp_chicken_9031;
-
-/*
-SET search_path = dbsnp_chicken_9031, pg_catalog;
-
-SET default_tablespace = '';
-
-SET default_with_oids = false;
-*/
 --
 -- Name: allelefreqbysspop; Type: TABLE; Schema: dbsnp_chicken_9031; Owner: -
 --
@@ -1190,16 +1178,6 @@ CREATE TABLE subsnpseqpos (
 );
 
 
-CREATE TABLE obsvariation (
-    var_id integer NOT NULL,
-    pattern character varying(1024) NOT NULL,
-    create_time timestamp without time zone NOT NULL,
-    last_updated_time timestamp without time zone,
-    univar_id integer,
-    var_flag smallint,
-    pattern_left character varying(900)
-);
-
 --
 -- Name: synonym; Type: TABLE; Schema: dbsnp_chicken_9031; Owner: -
 --
@@ -1578,9 +1556,6 @@ ALTER TABLE subsnpseqpos
 ALTER TABLE synonym
     ADD CONSTRAINT synonym_pkey PRIMARY KEY (subsnp_id, type);
 
-
-ALTER TABLE obsvariation
-    ADD CONSTRAINT obsvariation_pkey PRIMARY KEY (var_id);
 
 
 --
@@ -2147,8 +2122,23 @@ ALTER TABLE b150_snpmapinfo
 
 
 --
--- Name: dbsnp_chicken_9031; Type: ACL; Schema: -; Owner: -
+-- Name: dbsnp_shared; Type: SCHEMA; Schema: -; Owner: -
 --
+
+CREATE SCHEMA dbsnp_shared;
+
+CREATE TABLE dbsnp_shared.obsvariation (
+    var_id integer NOT NULL,
+    pattern character varying(1024) NOT NULL,
+    create_time timestamp without time zone NOT NULL,
+    last_updated_time timestamp without time zone,
+    univar_id integer,
+    var_flag smallint,
+    pattern_left character varying(900)
+);
+
+ALTER TABLE dbsnp_shared.obsvariation
+    ADD CONSTRAINT dbsnp_shared.obsvariation_pkey PRIMARY KEY (var_id);
 
 
 --


### PR DESCRIPTION
The table `obsvariation` belongs to a different schema than the rest of those queried by the import pipeline. This is now reflected in the code and the test data.

The testing database is composed of 2 schema:
* Organism data in PUBLIC schema (HSQLDB default)
* dbsnp_shared schema for `obsvariation` table

For the production environment, an example properties has been added, with an example of how to configure the organism schema in PostgreSQL. The shared schema is always made explicit in the queries.