### PR TITLE
EVA-930 Restrict variant search to a specific build

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
@@ -84,20 +84,20 @@ import java.util.stream.Collectors;
  */
 public class SampleReader extends JdbcPagingItemReader<Sample> {
 
-    public SampleReader(String dbsnpRelease, int batch, String assembly, List<String> assemblyTypes, DataSource dataSource, int pageSize)
-            throws Exception {
+    public SampleReader(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+                        DataSource dataSource, int pageSize) throws Exception {
         if (pageSize < 1) {
             throw new IllegalArgumentException("Page size must be greater than zero");
         }
 
         setDataSource(dataSource);
-        setQueryProvider(createQueryProvider(dataSource, dbsnpRelease));
-        setParameterValues(getParametersMap(dbsnpRelease, batch, assembly, assemblyTypes, dataSource));
+        setQueryProvider(createQueryProvider(dataSource, dbsnpBuild));
+        setParameterValues(getParametersMap(dbsnpBuild, batch, assembly, assemblyTypes, dataSource));
         setRowMapper(new SampleRowMapper());
         setPageSize(pageSize);
     }
 
-    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpRelease) throws Exception {
+    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpBuild) throws Exception {
         SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause(
@@ -122,8 +122,8 @@ public class SampleReader extends JdbcPagingItemReader<Sample> {
                         "JOIN population on population.pop_id = indiv.pop_id " +
                         "JOIN subsnp sub ON subind.subsnp_id = sub.subsnp_id " +
                         "JOIN snpsubsnplink link ON sub.subsnp_id = link.subsnp_id " +
-                        "JOIN b" + dbsnpRelease + "_snpcontigloc loc on loc.snp_id = link.snp_id " +
-                        "JOIN b" + dbsnpRelease + "_contiginfo ctg ON ctg.contig_gi = loc.ctg_id "
+                        "JOIN b" + dbsnpBuild + "_snpcontigloc loc on loc.snp_id = link.snp_id " +
+                        "JOIN b" + dbsnpBuild + "_contiginfo ctg ON ctg.contig_gi = loc.ctg_id "
         );
         factoryBean.setWhereClause(
                 "WHERE " +
@@ -137,18 +137,18 @@ public class SampleReader extends JdbcPagingItemReader<Sample> {
         return factoryBean.getObject();
     }
 
-    private Map<String, Object> getParametersMap(String dbsnpRelease, int batch, String assembly,
+    private Map<String, Object> getParametersMap(String dbsnpBuild, int batch, String assembly,
                                                  List<String> assemblyTypes,
                                                  DataSource dataSource) throws SQLException {
         Map<String, Object> parameterValues = new HashMap<>();
         parameterValues.put("assemblyType", assemblyTypes);
         parameterValues.put("assembly", assembly);
-        parameterValues.put("ss_id", getSubsnpId(dbsnpRelease, batch, assembly, assemblyTypes, dataSource));
+        parameterValues.put("ss_id", getSubsnpId(dbsnpBuild, batch, assembly, assemblyTypes, dataSource));
         parameterValues.put("batch", batch);
         return parameterValues;
     }
 
-    private Long getSubsnpId(String dbsnpRelease, int batch, String assembly, List<String> assemblyTypes,
+    private Long getSubsnpId(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
                              DataSource dataSource) throws SQLException {
         String joinedAssemblyTypes = assemblyTypes.stream().map(this::quote).collect(Collectors.joining(","));
 
@@ -161,8 +161,8 @@ public class SampleReader extends JdbcPagingItemReader<Sample> {
                         "    JOIN batch on subind.batch_id = batch.batch_id" +
                         "    JOIN subsnp sub ON subind.subsnp_id = sub.subsnp_id" +
                         "    JOIN snpsubsnplink link ON sub.subsnp_id = link.subsnp_id" +
-                        "    JOIN b" + dbsnpRelease + "_snpcontigloc loc on loc.snp_id = link.snp_id" +
-                        "    JOIN b" + dbsnpRelease + "_contiginfo ctg ON ctg.contig_gi = loc.ctg_id" +
+                        "    JOIN b" + dbsnpBuild + "_snpcontigloc loc on loc.snp_id = link.snp_id" +
+                        "    JOIN b" + dbsnpBuild + "_contiginfo ctg ON ctg.contig_gi = loc.ctg_id" +
                         "  WHERE " +
                         "    batch.batch_id = " + quote(String.valueOf(batch)) +
                         "    AND ctg.group_label LIKE " + quote(assembly) +

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
@@ -84,7 +84,7 @@ import java.util.stream.Collectors;
  */
 public class SampleReader extends JdbcPagingItemReader<Sample> {
 
-    public SampleReader(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+    public SampleReader(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
                         DataSource dataSource, int pageSize) throws Exception {
         if (pageSize < 1) {
             throw new IllegalArgumentException("Page size must be greater than zero");
@@ -97,7 +97,7 @@ public class SampleReader extends JdbcPagingItemReader<Sample> {
         setPageSize(pageSize);
     }
 
-    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpBuild) throws Exception {
+    private PagingQueryProvider createQueryProvider(DataSource dataSource, int dbsnpBuild) throws Exception {
         SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause(
@@ -137,7 +137,7 @@ public class SampleReader extends JdbcPagingItemReader<Sample> {
         return factoryBean.getObject();
     }
 
-    private Map<String, Object> getParametersMap(String dbsnpBuild, int batch, String assembly,
+    private Map<String, Object> getParametersMap(int dbsnpBuild, int batch, String assembly,
                                                  List<String> assemblyTypes,
                                                  DataSource dataSource) throws SQLException {
         Map<String, Object> parameterValues = new HashMap<>();
@@ -148,7 +148,7 @@ public class SampleReader extends JdbcPagingItemReader<Sample> {
         return parameterValues;
     }
 
-    private Long getSubsnpId(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+    private Long getSubsnpId(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
                              DataSource dataSource) throws SQLException {
         String joinedAssemblyTypes = assemblyTypes.stream().map(this::quote).collect(Collectors.joining(","));
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
@@ -18,8 +18,6 @@ package uk.ac.ebi.eva.dbsnpimporter.io.readers;
 import org.springframework.batch.item.database.JdbcPagingItemReader;
 import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
-import org.springframework.dao.DataAccessException;
-import org.springframework.dao.NonTransientDataAccessException;
 import org.springframework.jdbc.BadSqlGrammarException;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -15,8 +15,6 @@
  */
 package uk.ac.ebi.eva.dbsnpimporter.io.readers;
 
-import org.springframework.batch.item.ParseException;
-import org.springframework.batch.item.UnexpectedInputException;
 import org.springframework.batch.item.database.JdbcPagingItemReader;
 import org.springframework.batch.item.database.PagingQueryProvider;
 import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -102,7 +102,7 @@ import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.S
  */
 public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreFields> {
 
-    public SubSnpCoreFieldsReader(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+    public SubSnpCoreFieldsReader(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
                                   DataSource dataSource, int pageSize) throws Exception {
         if (pageSize < 1) {
             throw new IllegalArgumentException("Page size must be greater than zero");
@@ -115,7 +115,7 @@ public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreField
         setPageSize(pageSize);
     }
 
-    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpBuild) throws Exception {
+    private PagingQueryProvider createQueryProvider(DataSource dataSource, int dbsnpBuild) throws Exception {
         SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause(

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -102,20 +102,20 @@ import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.S
  */
 public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreFields> {
 
-    public SubSnpCoreFieldsReader(int batch, String assembly, List<String> assemblyTypes, DataSource dataSource,
+    public SubSnpCoreFieldsReader(String dbsnpRelease, int batch, String assembly, List<String> assemblyTypes, DataSource dataSource,
                                   int pageSize) throws Exception {
         if (pageSize < 1) {
             throw new IllegalArgumentException("Page size must be greater than zero");
         }
 
         setDataSource(dataSource);
-        setQueryProvider(createQueryProvider(dataSource));
+        setQueryProvider(createQueryProvider(dataSource, dbsnpRelease));
         setParameterValues(getParametersMap(batch, assembly, assemblyTypes));
         setRowMapper(new SubSnpCoreFieldsRowMapper());
         setPageSize(pageSize);
     }
 
-    private PagingQueryProvider createQueryProvider(DataSource dataSource) throws Exception {
+    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpRelease) throws Exception {
         SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause(
@@ -156,12 +156,12 @@ public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreField
         );
         factoryBean.setFromClause(
                 "FROM " +
-                        "b150_snpcontigloc loc JOIN " +
-                        "b150_contiginfo ctg ON ctg.contig_gi = loc.ctg_id JOIN " +
+                        "b" + dbsnpRelease + "_snpcontigloc loc JOIN " +
+                        "b" + dbsnpRelease + "_contiginfo ctg ON ctg.ctg_id = loc.ctg_id JOIN " +
                         "snpsubsnplink link ON loc.snp_id = link.snp_id JOIN " +
                         "subsnp sub ON link.subsnp_id = sub.subsnp_id JOIN " +
                         "batch on sub.batch_id = batch.batch_id JOIN " +
-                        "b150_snphgvslink hgvs ON hgvs.snp_link = loc.snp_id JOIN " +
+                        "b" + dbsnpRelease + "_snphgvslink hgvs ON hgvs.snp_link = loc.snp_id JOIN " +
                         "dbsnp_shared.obsvariation ON obsvariation.var_id = sub.variation_id"
         );
         factoryBean.setWhereClause(

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -102,20 +102,20 @@ import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.S
  */
 public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreFields> {
 
-    public SubSnpCoreFieldsReader(String dbsnpRelease, int batch, String assembly, List<String> assemblyTypes, DataSource dataSource,
-                                  int pageSize) throws Exception {
+    public SubSnpCoreFieldsReader(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+                                  DataSource dataSource, int pageSize) throws Exception {
         if (pageSize < 1) {
             throw new IllegalArgumentException("Page size must be greater than zero");
         }
 
         setDataSource(dataSource);
-        setQueryProvider(createQueryProvider(dataSource, dbsnpRelease));
+        setQueryProvider(createQueryProvider(dataSource, dbsnpBuild));
         setParameterValues(getParametersMap(batch, assembly, assemblyTypes));
         setRowMapper(new SubSnpCoreFieldsRowMapper());
         setPageSize(pageSize);
     }
 
-    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpRelease) throws Exception {
+    private PagingQueryProvider createQueryProvider(DataSource dataSource, String dbsnpBuild) throws Exception {
         SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause(
@@ -156,12 +156,12 @@ public class SubSnpCoreFieldsReader extends JdbcPagingItemReader<SubSnpCoreField
         );
         factoryBean.setFromClause(
                 "FROM " +
-                        "b" + dbsnpRelease + "_snpcontigloc loc JOIN " +
-                        "b" + dbsnpRelease + "_contiginfo ctg ON ctg.ctg_id = loc.ctg_id JOIN " +
+                        "b" + dbsnpBuild + "_snpcontigloc loc JOIN " +
+                        "b" + dbsnpBuild + "_contiginfo ctg ON ctg.ctg_id = loc.ctg_id JOIN " +
                         "snpsubsnplink link ON loc.snp_id = link.snp_id JOIN " +
                         "subsnp sub ON link.subsnp_id = sub.subsnp_id JOIN " +
                         "batch on sub.batch_id = batch.batch_id JOIN " +
-                        "b" + dbsnpRelease + "_snphgvslink hgvs ON hgvs.snp_link = loc.snp_id JOIN " +
+                        "b" + dbsnpBuild + "_snphgvslink hgvs ON hgvs.snp_link = loc.snp_id JOIN " +
                         "dbsnp_shared.obsvariation ON obsvariation.var_id = sub.variation_id"
         );
         factoryBean.setWhereClause(

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
@@ -57,13 +57,11 @@ public class SampleReaderTest extends ReaderTest {
 
     public static final int BATCH_ID = 12070;
 
-    public static final int WRONG_BATCH_ID = -1;
-
     public static final int FIRST_SUBMITTED_INDIVIDUAL_ID = 6480;
 
     public static final int SECOND_SUBMITTED_INDIVIDUAL_ID = 6483;
 
-    public static final String DBSNP_RELEASE = "150";
+    public static final String DBSNP_BUILD = "150";
 
     @Autowired
     private DataSource dataSource;
@@ -77,7 +75,7 @@ public class SampleReaderTest extends ReaderTest {
 
     @Before
     public void setUp() throws Exception {
-        reader = buildReader(DBSNP_RELEASE, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+        reader = buildReader(DBSNP_BUILD, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
 
         Map<String, String> cohorts = new HashMap<>();
@@ -94,10 +92,10 @@ public class SampleReaderTest extends ReaderTest {
         return String.valueOf(batchId) + "_" + String.valueOf(submittedIndividualId);
     }
 
-    private SampleReader buildReader(String dbsnpRelease, int batch, String assembly, List<String> assemblyTypes,
+    private SampleReader buildReader(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
                                      int pageSize)
             throws Exception {
-        SampleReader fieldsReader = new SampleReader(dbsnpRelease, batch, assembly, assemblyTypes, dataSource,
+        SampleReader fieldsReader = new SampleReader(dbsnpBuild, batch, assembly, assemblyTypes, dataSource,
                 pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
@@ -128,27 +126,30 @@ public class SampleReaderTest extends ReaderTest {
 
     @Test
     public void testQueryWithDifferentRelease() throws Exception {
+        String dbsnpBuild = "130";
+
         exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
-        buildReader("130", BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        buildReader(dbsnpBuild, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
     }
 
     @Test
     public void testQueryWithDifferentAssembly() throws Exception {
         exception.expect(NoSuchElementException.class);
-        buildReader(DBSNP_RELEASE, BATCH_ID, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY),
-                    PAGE_SIZE);
+        buildReader(DBSNP_BUILD, BATCH_ID, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
     }
 
     @Test
     public void testQueryWithDifferentAssemblyType() throws Exception {
         exception.expect(NoSuchElementException.class);
-        buildReader(DBSNP_RELEASE, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR), PAGE_SIZE);
+        buildReader(DBSNP_BUILD, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR), PAGE_SIZE);
     }
 
     @Test
     public void testQueryWithDifferentBatch() throws Exception {
+        int nonExistingBatchId = -1;
+
         exception.expect(NoSuchElementException.class);
-        buildReader(DBSNP_RELEASE, WRONG_BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+        buildReader(DBSNP_BUILD, nonExistingBatchId, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                     PAGE_SIZE);
     }
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
@@ -61,7 +61,7 @@ public class SampleReaderTest extends ReaderTest {
 
     public static final int SECOND_SUBMITTED_INDIVIDUAL_ID = 6483;
 
-    public static final String DBSNP_BUILD = "150";
+    public static final int DBSNP_BUILD = 150;
 
     @Autowired
     private DataSource dataSource;
@@ -92,11 +92,9 @@ public class SampleReaderTest extends ReaderTest {
         return String.valueOf(batchId) + "_" + String.valueOf(submittedIndividualId);
     }
 
-    private SampleReader buildReader(String dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
-                                     int pageSize)
-            throws Exception {
-        SampleReader fieldsReader = new SampleReader(dbsnpBuild, batch, assembly, assemblyTypes, dataSource,
-                pageSize);
+    private SampleReader buildReader(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+                                     int pageSize) throws Exception {
+        SampleReader fieldsReader = new SampleReader(dbsnpBuild, batch, assembly, assemblyTypes, dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);
@@ -126,7 +124,7 @@ public class SampleReaderTest extends ReaderTest {
 
     @Test
     public void testQueryWithDifferentRelease() throws Exception {
-        String dbsnpBuild = "130";
+        int dbsnpBuild = 130;
 
         exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
         buildReader(dbsnpBuild, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
@@ -30,6 +30,7 @@ import uk.ac.ebi.eva.commons.core.models.pedigree.Sex;
 import uk.ac.ebi.eva.dbsnpimporter.models.Sample;
 
 import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -126,7 +127,7 @@ public class SampleReaderTest extends ReaderTest {
     public void testQueryWithDifferentRelease() throws Exception {
         int dbsnpBuild = 130;
 
-        exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
+        exception.expect(SQLException.class);
         buildReader(dbsnpBuild, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
     }
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
@@ -77,7 +77,8 @@ public class SampleReaderTest extends ReaderTest {
 
     @Before
     public void setUp() throws Exception {
-        reader = buildReader(BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+                             PAGE_SIZE);
 
         Map<String, String> cohorts = new HashMap<>();
         cohorts.put(SampleRowMapper.POPULATION, "RBLS");
@@ -93,10 +94,11 @@ public class SampleReaderTest extends ReaderTest {
         return String.valueOf(batchId) + "_" + String.valueOf(submittedIndividualId);
     }
 
-    private SampleReader buildReader(int batch, String assembly, List<String> assemblyTypes, int pageSize)
+    private SampleReader buildReader(String dbsnpRelease, int batch, String assembly, List<String> assemblyTypes,
+                                     int pageSize)
             throws Exception {
-        SampleReader fieldsReader = new SampleReader(DBSNP_RELEASE, batch, assembly, assemblyTypes, dataSource,
-                                                     pageSize);
+        SampleReader fieldsReader = new SampleReader(dbsnpRelease, batch, assembly, assemblyTypes, dataSource,
+                pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);
@@ -125,20 +127,29 @@ public class SampleReaderTest extends ReaderTest {
     }
 
     @Test
+    public void testQueryWithDifferentRelease() throws Exception {
+        exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
+        buildReader("130", BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+    }
+
+    @Test
     public void testQueryWithDifferentAssembly() throws Exception {
         exception.expect(NoSuchElementException.class);
-        buildReader(BATCH_ID, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        buildReader(DBSNP_RELEASE, BATCH_ID, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY),
+                    PAGE_SIZE);
     }
 
     @Test
     public void testQueryWithDifferentAssemblyType() throws Exception {
         exception.expect(NoSuchElementException.class);
-        buildReader(BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR), PAGE_SIZE);
+        buildReader(DBSNP_RELEASE, BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR), PAGE_SIZE);
     }
 
     @Test
     public void testQueryWithDifferentBatch() throws Exception {
         exception.expect(NoSuchElementException.class);
-        buildReader(WRONG_BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        buildReader(DBSNP_RELEASE, WRONG_BATCH_ID, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+                    PAGE_SIZE);
     }
+
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
@@ -54,6 +54,8 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     private static final int BATCH = 11825;
 
+    public static final String DBSNP_RELEASE = "150";
+
     @Autowired
     private DataSource dataSource;
 
@@ -142,8 +144,8 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     private SubSnpCoreFieldsReader buildReader(int batch, String assembly, List<String> assemblyTypes, int pageSize)
             throws Exception {
-        SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(batch, assembly, assemblyTypes, dataSource,
-                                                                         pageSize);
+        SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(DBSNP_RELEASE, batch, assembly, assemblyTypes,
+                                                                         dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
@@ -17,7 +17,9 @@ package uk.ac.ebi.eva.dbsnpimporter.io.readers;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,6 +64,9 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
     private SubSnpCoreFieldsReader reader;
 
     private List<SubSnpCoreFields> expectedSubsnps;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -142,10 +147,11 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                  "NT_455866.1:g.1766472T>C", 1766472L, 1766472L, 1));
     }
 
-    private SubSnpCoreFieldsReader buildReader(int batch, String assembly, List<String> assemblyTypes, int pageSize)
+    private SubSnpCoreFieldsReader buildReader(String dbsnpRelease, int batch, String assembly,
+                                               List<String> assemblyTypes, int pageSize)
             throws Exception {
-        SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(DBSNP_RELEASE, batch, assembly, assemblyTypes,
-                                                                         dataSource, pageSize);
+        SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(dbsnpRelease, batch, assembly, assemblyTypes,
+                dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);
@@ -159,14 +165,16 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testLoadData() throws Exception {
-        reader = buildReader(BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+                             PAGE_SIZE);
         assertNotNull(reader);
         assertEquals(PAGE_SIZE, reader.getPageSize());
     }
 
     @Test
     public void testQuery() throws Exception {
-        reader = buildReader(BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+                             PAGE_SIZE);
         List<SubSnpCoreFields> readSnps = readAll(reader);
 
         assertEquals(21, readSnps.size());
@@ -180,13 +188,22 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
         checkSnpOrientation(readSnps, 733889725L, Orientation.REVERSE, Orientation.REVERSE);
     }
 
-
     private void checkSnpOrientation(List<SubSnpCoreFields> readSnps, Long snpId, Orientation snpOrientation,
                                      Orientation contigOrientation) {
         Optional<SubSnpCoreFields> snp = readSnps.stream().filter(s -> s.getRsId().equals(snpId)).findAny();
         assertTrue(snp.isPresent());
         assertEquals(snpOrientation, snp.get().getSnpOrientation());
         assertEquals(contigOrientation, snp.get().getContigOrientation());
+    }
+
+    @Test
+    public void testQueryWithDifferentRelease() throws Exception {
+        String dbsnpRelease = "130";
+        reader = buildReader(dbsnpRelease, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+                             PAGE_SIZE);
+
+        exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
+        List<SubSnpCoreFields> list = readAll(reader);
     }
 
     @Test
@@ -207,7 +224,8 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                          47119827L, 47119830L, 1,
                                                          "NT_455837.1:g.11724980_11724983delCCGA",
                                                          11724980L, 11724983L, -1));
-        reader = buildReader(1062064, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, 1062064, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY),
+                             PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
 
         assertEquals(1, list.size());
@@ -216,14 +234,16 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testQueryWithDifferentAssemblyType() throws Exception {
-        reader = buildReader(BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR), PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR),
+                             PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
         assertEquals(0, list.size());
     }
 
     @Test
     public void testQueryWithDifferentBatch() throws Exception {
-        reader = buildReader(1062063, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, 1062063, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+                             PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
         assertEquals(1, list.size());
     }
@@ -231,8 +251,8 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
     @Test
     public void testQueryWithNonExistingBatch() throws Exception {
         int nonExistingBatch = 42;
-        reader = buildReader(nonExistingBatch, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
-                             PAGE_SIZE);
+        reader = buildReader(DBSNP_RELEASE, nonExistingBatch, CHICKEN_ASSEMBLY_5,
+                             Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
         assertEquals(0, list.size());
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
@@ -56,7 +56,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     private static final int BATCH = 11825;
 
-    public static final String DBSNP_RELEASE = "150";
+    public static final String DBSNP_BUILD = "150";
 
     @Autowired
     private DataSource dataSource;
@@ -147,10 +147,10 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                  "NT_455866.1:g.1766472T>C", 1766472L, 1766472L, 1));
     }
 
-    private SubSnpCoreFieldsReader buildReader(String dbsnpRelease, int batch, String assembly,
+    private SubSnpCoreFieldsReader buildReader(String dbsnpBuild, int batch, String assembly,
                                                List<String> assemblyTypes, int pageSize)
             throws Exception {
-        SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(dbsnpRelease, batch, assembly, assemblyTypes,
+        SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(dbsnpBuild, batch, assembly, assemblyTypes,
                 dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
@@ -165,7 +165,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testLoadData() throws Exception {
-        reader = buildReader(DBSNP_RELEASE, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+        reader = buildReader(DBSNP_BUILD, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
         assertNotNull(reader);
         assertEquals(PAGE_SIZE, reader.getPageSize());
@@ -173,7 +173,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testQuery() throws Exception {
-        reader = buildReader(DBSNP_RELEASE, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+        reader = buildReader(DBSNP_BUILD, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
         List<SubSnpCoreFields> readSnps = readAll(reader);
 
@@ -198,8 +198,8 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testQueryWithDifferentRelease() throws Exception {
-        String dbsnpRelease = "130";
-        reader = buildReader(dbsnpRelease, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+        String dbsnpBuild = "130";
+        reader = buildReader(dbsnpBuild, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
 
         exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
@@ -224,7 +224,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                          47119827L, 47119830L, 1,
                                                          "NT_455837.1:g.11724980_11724983delCCGA",
                                                          11724980L, 11724983L, -1));
-        reader = buildReader(DBSNP_RELEASE, 1062064, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY),
+        reader = buildReader(DBSNP_BUILD, 1062064, CHICKEN_ASSEMBLY_4, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
 
@@ -234,15 +234,14 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testQueryWithDifferentAssemblyType() throws Exception {
-        reader = buildReader(DBSNP_RELEASE, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR),
-                             PAGE_SIZE);
+        reader = buildReader(DBSNP_BUILD, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(NON_NUCLEAR), PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
         assertEquals(0, list.size());
     }
 
     @Test
     public void testQueryWithDifferentBatch() throws Exception {
-        reader = buildReader(DBSNP_RELEASE, 1062063, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
+        reader = buildReader(DBSNP_BUILD, 1062063, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
         assertEquals(1, list.size());
@@ -251,7 +250,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
     @Test
     public void testQueryWithNonExistingBatch() throws Exception {
         int nonExistingBatch = 42;
-        reader = buildReader(DBSNP_RELEASE, nonExistingBatch, CHICKEN_ASSEMBLY_5,
+        reader = buildReader(DBSNP_BUILD, nonExistingBatch, CHICKEN_ASSEMBLY_5,
                              Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
         List<SubSnpCoreFields> list = readAll(reader);
         assertEquals(0, list.size());

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
@@ -56,7 +56,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     private static final int BATCH = 11825;
 
-    public static final String DBSNP_BUILD = "150";
+    public static final int DBSNP_BUILD = 150;
 
     @Autowired
     private DataSource dataSource;
@@ -147,11 +147,10 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                  "NT_455866.1:g.1766472T>C", 1766472L, 1766472L, 1));
     }
 
-    private SubSnpCoreFieldsReader buildReader(String dbsnpBuild, int batch, String assembly,
-                                               List<String> assemblyTypes, int pageSize)
-            throws Exception {
+    private SubSnpCoreFieldsReader buildReader(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
+                                               int pageSize) throws Exception {
         SubSnpCoreFieldsReader fieldsReader = new SubSnpCoreFieldsReader(dbsnpBuild, batch, assembly, assemblyTypes,
-                dataSource, pageSize);
+                                                                         dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);
@@ -198,7 +197,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
 
     @Test
     public void testQueryWithDifferentRelease() throws Exception {
-        String dbsnpBuild = "130";
+        int dbsnpBuild = 130;
         reader = buildReader(dbsnpBuild, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
@@ -30,6 +30,7 @@ import uk.ac.ebi.eva.dbsnpimporter.models.Orientation;
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 
 import javax.sql.DataSource;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -201,7 +202,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
         reader = buildReader(dbsnpBuild, BATCH, CHICKEN_ASSEMBLY_5, Collections.singletonList(PRIMARY_ASSEMBLY),
                              PAGE_SIZE);
 
-        exception.expect(org.springframework.jdbc.BadSqlGrammarException.class);
+        exception.expect(SQLException.class);
         List<SubSnpCoreFields> list = readAll(reader);
     }
 


### PR DESCRIPTION
The names of some of the tables queried for variants depend on the dbSNP build number. For instance, `b150_snpcontigloc` belongs to build 150 and `b140_snpcontigloc` to build 140.

This has been added as a parameter for the variants reader, following the same structure that was already implemented for the samples search.