### PR TITLE
EVA-883 - Read sample genotypes associated with an ss

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReader.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.io.readers;
+
+import org.springframework.batch.item.database.JdbcPagingItemReader;
+import org.springframework.batch.item.database.PagingQueryProvider;
+import org.springframework.batch.item.database.support.SqlPagingQueryProviderFactoryBean;
+
+import org.springframework.jdbc.BadSqlGrammarException;
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpGenotype;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.BATCH_ID_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.LOC_BATCH_ID_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.SUBSNP_ID_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.GENOTYPES_COLUMN;
+
+
+public class SubSnpGenotypeReader extends JdbcPagingItemReader<SubSnpGenotype> {
+
+    private final int batch;
+
+    public SubSnpGenotypeReader(int batch, DataSource dataSource, int pageSize) throws Exception {
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("Page size must be greater than zero");
+        }
+
+        this.batch = batch;
+
+        setDataSource(dataSource);
+        setQueryProvider(createQueryProvider(dataSource));
+        setParameterValues(getParametersMap(batch));
+        setRowMapper(new SubSnpGenotypeRowMapper());
+        setPageSize(pageSize);
+    }
+
+    @Override
+    public SubSnpGenotype read() throws Exception {
+        try {
+            return super.read();
+        } catch (BadSqlGrammarException e) {
+            throw new SQLException("Could not read SubSNP Genotype for batch:" + batch , e);
+        }
+    }
+
+    private PagingQueryProvider createQueryProvider(DataSource dataSource) throws Exception {
+        SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
+        factoryBean.setDataSource(dataSource);
+        factoryBean.setSelectClause("select " +
+                "batch.batch_id as " + BATCH_ID_COLUMN +
+                ", loc_batch_id as " + LOC_BATCH_ID_COLUMN +
+                ", subsnp_id as " + SUBSNP_ID_COLUMN +
+                ", genotypes_string as " + GENOTYPES_COLUMN);
+        factoryBean.setFromClause("from subsnpgenotypes join batch on subsnpgenotypes.batch_id = batch.batch_id");
+        factoryBean.setSortKey(SUBSNP_ID_COLUMN);
+        factoryBean.setWhereClause(
+                "WHERE batch_id = :batch"
+        );
+        return factoryBean.getObject();
+    }
+
+    private Map<String, Object> getParametersMap(int batch) {
+        Map<String, Object> parameterValues = new HashMap<>();
+        parameterValues.put("batch", batch);
+        return parameterValues;
+    }
+}

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReader.java
@@ -56,7 +56,7 @@ public class SubSnpGenotypeReader extends JdbcPagingItemReader<SubSnpGenotype> {
         try {
             return super.read();
         } catch (BadSqlGrammarException e) {
-            throw new SQLException("Could not read SubSNP Genotype for batch:" + batch , e);
+            throw new SQLException("Could not read SubSNP Genotype for batch: " + batch , e);
         }
     }
 
@@ -64,11 +64,11 @@ public class SubSnpGenotypeReader extends JdbcPagingItemReader<SubSnpGenotype> {
         SqlPagingQueryProviderFactoryBean factoryBean = new SqlPagingQueryProviderFactoryBean();
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause("select " +
-                "batch.batch_id as " + BATCH_ID_COLUMN +
-                ", batch.batch_id as " + STUDY_ID_COLUMN + //Batch ID serves as both file ID and study ID
+                "batch_id as " + BATCH_ID_COLUMN +
+                ", batch_id as " + STUDY_ID_COLUMN + //Batch ID serves as both file ID and study ID
                 ", subsnp_id as " + SUBSNP_ID_COLUMN +
                 ", genotypes_string as " + GENOTYPES_COLUMN);
-        factoryBean.setFromClause("from subsnpgenotypes join batch on subsnpgenotypes.batch_id = batch.batch_id");
+        factoryBean.setFromClause("from subsnpgenotypes");
         factoryBean.setSortKey(SUBSNP_ID_COLUMN);
         factoryBean.setWhereClause(
                 "WHERE batch_id = :batch"

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReader.java
@@ -28,7 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.BATCH_ID_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.LOC_BATCH_ID_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.STUDY_ID_COLUMN;
 import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.SUBSNP_ID_COLUMN;
 import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper.GENOTYPES_COLUMN;
 
@@ -65,7 +65,7 @@ public class SubSnpGenotypeReader extends JdbcPagingItemReader<SubSnpGenotype> {
         factoryBean.setDataSource(dataSource);
         factoryBean.setSelectClause("select " +
                 "batch.batch_id as " + BATCH_ID_COLUMN +
-                ", loc_batch_id as " + LOC_BATCH_ID_COLUMN +
+                ", batch.batch_id as " + STUDY_ID_COLUMN + //Batch ID serves as both file ID and study ID
                 ", subsnp_id as " + SUBSNP_ID_COLUMN +
                 ", genotypes_string as " + GENOTYPES_COLUMN);
         factoryBean.setFromClause("from subsnpgenotypes join batch on subsnpgenotypes.batch_id = batch.batch_id");

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeRowMapper.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeRowMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.io.readers;
+
+import org.springframework.jdbc.core.RowMapper;
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpGenotype;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * Maps the database fields that correspond to an SS ID along with the associated genotypes.
+ */
+public class SubSnpGenotypeRowMapper implements RowMapper<SubSnpGenotype> {
+
+    public static final String BATCH_ID_COLUMN = "batch_id";
+
+    public static final String LOC_BATCH_ID_COLUMN = "loc_batch_id";
+
+    public static final String SUBSNP_ID_COLUMN = "ss_id";
+
+    public static final String GENOTYPES_COLUMN = "genotypes_string";
+
+    public static final String GENOTYPE_DELIMITER = ",";
+
+    /**
+     * Maps ResultSet to SubSnpCoreFields.
+     *
+     * It makes getObject (instead of getInt or getString) for those that are nullable.
+     *
+     * The casts are safe because the DB types are integers. The types Long and BigDecimal are introduced by the query
+     * and it won't change the values more that +-1.
+     */
+    @Override
+    public SubSnpGenotype mapRow(ResultSet resultSet, int rowNum) throws SQLException {
+        return new SubSnpGenotype(resultSet.getInt(BATCH_ID_COLUMN), resultSet.getString(LOC_BATCH_ID_COLUMN),
+                resultSet.getLong(SUBSNP_ID_COLUMN), resultSet.getString(GENOTYPES_COLUMN));
+    }
+}

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeRowMapper.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeRowMapper.java
@@ -27,7 +27,7 @@ public class SubSnpGenotypeRowMapper implements RowMapper<SubSnpGenotype> {
 
     public static final String BATCH_ID_COLUMN = "batch_id";
 
-    public static final String LOC_BATCH_ID_COLUMN = "loc_batch_id";
+    public static final String STUDY_ID_COLUMN = "study_id";
 
     public static final String SUBSNP_ID_COLUMN = "ss_id";
 
@@ -45,7 +45,7 @@ public class SubSnpGenotypeRowMapper implements RowMapper<SubSnpGenotype> {
      */
     @Override
     public SubSnpGenotype mapRow(ResultSet resultSet, int rowNum) throws SQLException {
-        return new SubSnpGenotype(resultSet.getInt(BATCH_ID_COLUMN), resultSet.getString(LOC_BATCH_ID_COLUMN),
+        return new SubSnpGenotype(resultSet.getInt(BATCH_ID_COLUMN), resultSet.getString(STUDY_ID_COLUMN),
                 resultSet.getLong(SUBSNP_ID_COLUMN), resultSet.getString(GENOTYPES_COLUMN));
     }
 }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
@@ -16,7 +16,6 @@
 package uk.ac.ebi.eva.dbsnpimporter.models;
 
 
-import uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeReader;
 import uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper;
 
 import java.util.ArrayList;
@@ -30,21 +29,21 @@ import java.util.stream.Collectors;
 public class SubSnpGenotype {
 
     private int batchId;
-    private String locBatchId;
+    private String studyId;
     private long ssId;
     private List<String> genotypes;
 
     /**
      * @param batchId           Unique Batch identifier (maps to "fid" attribute in
      *                          files sub-document under the variants document in Mongo)
-     * @param locBatchId        Unique study identifier (maps to "sid" attribute in
+     * @param studyId        Unique study identifier (maps to "sid" attribute in
      *                          files sub-document under the variants document in Mongo)
      * @param subSnpId          Unique SS ID identifier
      * @param genotypes         Genotypes associated with the SS
      */
-    public SubSnpGenotype(int batchId, String locBatchId, long subSnpId, String genotypes) {
+    public SubSnpGenotype(int batchId, String studyId, long subSnpId, String genotypes) {
         this.batchId = batchId;
-        this.locBatchId = locBatchId;
+        this.studyId = studyId;
         this.ssId = subSnpId;
         if (genotypes == null || genotypes.trim().equals(""))
         {
@@ -61,8 +60,8 @@ public class SubSnpGenotype {
         return batchId;
     }
 
-    public String getLocBatchId() {
-        return locBatchId;
+    public String getStudyId() {
+        return studyId;
     }
 
     public long getSsId() {
@@ -78,7 +77,7 @@ public class SubSnpGenotype {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SubSnpGenotype that = (SubSnpGenotype) o;
-        return (batchId == that.batchId && locBatchId.equals(that.locBatchId) && ssId == that.ssId
+        return (batchId == that.batchId && studyId.equals(that.studyId) && ssId == that.ssId
                 && genotypes.equals(that.genotypes));
     }
 }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
@@ -50,8 +50,7 @@ public class SubSnpGenotype {
         this.ssId = subSnpId;
         if (genotypes == null || genotypes.trim().equals("")) {
             this.genotypes = new ArrayList<>();
-        }
-        else {
+        } else {
             this.genotypes = Arrays.stream(genotypes.split(SubSnpGenotypeRowMapper.GENOTYPE_DELIMITER))
                     .map(String::trim).collect(Collectors.toList());
         }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.models;
+
+
+import uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeReader;
+import uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpGenotypeRowMapper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Representation for Genotypes associated with a given SubSNP
+ */
+public class SubSnpGenotype {
+
+    private int batchId;
+    private String locBatchId;
+    private long ssId;
+    private List<String> genotypes;
+
+    /**
+     * @param batchId           Unique Batch identifier (maps to "fid" attribute in
+     *                          files sub-document under the variants document in Mongo)
+     * @param locBatchId        Unique study identifier (maps to "sid" attribute in
+     *                          files sub-document under the variants document in Mongo)
+     * @param subSnpId          Unique SS ID identifier
+     * @param genotypes         Genotypes associated with the SS
+     */
+    public SubSnpGenotype(int batchId, String locBatchId, long subSnpId, String genotypes) {
+        this.batchId = batchId;
+        this.locBatchId = locBatchId;
+        this.ssId = subSnpId;
+        if (genotypes == null || genotypes.trim().equals(""))
+        {
+            this.genotypes = new ArrayList<>();
+        }
+        else
+        {
+            this.genotypes = Arrays.stream(genotypes.split(SubSnpGenotypeRowMapper.GENOTYPE_DELIMITER))
+                    .map(String::trim).collect(Collectors.toList());
+        }
+    }
+
+    public long getBatchId() {
+        return batchId;
+    }
+
+    public String getLocBatchId() {
+        return locBatchId;
+    }
+
+    public long getSsId() {
+        return ssId;
+    }
+
+    public List<String> getGenotypes() {
+        return genotypes;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SubSnpGenotype that = (SubSnpGenotype) o;
+        return (batchId == that.batchId && locBatchId.equals(that.locBatchId) && ssId == that.ssId
+                && genotypes.equals(that.genotypes));
+    }
+}

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotype.java
@@ -29,8 +29,11 @@ import java.util.stream.Collectors;
 public class SubSnpGenotype {
 
     private int batchId;
+
     private String studyId;
+
     private long ssId;
+
     private List<String> genotypes;
 
     /**
@@ -45,12 +48,10 @@ public class SubSnpGenotype {
         this.batchId = batchId;
         this.studyId = studyId;
         this.ssId = subSnpId;
-        if (genotypes == null || genotypes.trim().equals(""))
-        {
+        if (genotypes == null || genotypes.trim().equals("")) {
             this.genotypes = new ArrayList<>();
         }
-        else
-        {
+        else {
             this.genotypes = Arrays.stream(genotypes.split(SubSnpGenotypeRowMapper.GENOTYPE_DELIMITER))
                     .map(String::trim).collect(Collectors.toList());
         }
@@ -72,12 +73,26 @@ public class SubSnpGenotype {
         return genotypes;
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
+
         SubSnpGenotype that = (SubSnpGenotype) o;
-        return (batchId == that.batchId && studyId.equals(that.studyId) && ssId == that.ssId
-                && genotypes.equals(that.genotypes));
+
+        if (batchId != that.batchId) return false;
+        if (ssId != that.ssId) return false;
+        if (studyId != null ? !studyId.equals(that.studyId) : that.studyId != null) return false;
+        return genotypes != null ? genotypes.equals(that.genotypes) : that.genotypes == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = batchId;
+        result = 31 * result + (studyId != null ? studyId.hashCode() : 0);
+        result = 31 * result + (int) (ssId ^ (ssId >>> 32));
+        result = 31 * result + (genotypes != null ? genotypes.hashCode() : 0);
+        return result;
     }
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReaderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.io.readers;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.batch.item.ExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpGenotype;
+
+import javax.sql.DataSource;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static uk.ac.ebi.eva.dbsnpimporter.test.TestUtils.assertContains;
+
+@RunWith(SpringRunner.class)
+@JdbcTest
+public class SubSnpGenotypeReaderTest extends ReaderTest {
+
+    private static final int PAGE_SIZE = 2000;
+
+    private static final int BATCH = 12068;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private SubSnpGenotypeReader reader;
+
+    private List<SubSnpGenotype> expectedSubSnpGenotyes;
+
+    @Before
+    public void setUp() {
+        expectedSubSnpGenotyes = new ArrayList<>();
+
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505332, "C/C,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505333, "G/G,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505335, "A/A,C/C"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505336, "C/C,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505337, "G/G,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505339, "C/C,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505340, "C/C,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505342, "C/C,T/T"));
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+                26505343, "-/-,C/C"));
+    }
+
+    private SubSnpGenotypeReader buildReader(int batch, int pageSize) throws Exception {
+        SubSnpGenotypeReader fieldsReader = new SubSnpGenotypeReader(batch, dataSource, pageSize);
+        fieldsReader.afterPropertiesSet();
+        ExecutionContext executionContext = new ExecutionContext();
+        fieldsReader.open(executionContext);
+        return fieldsReader;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        reader.close();
+    }
+
+    @Test
+    public void testLoadData() throws Exception {
+        reader = buildReader(BATCH, PAGE_SIZE);
+        assertNotNull(reader);
+        assertEquals(PAGE_SIZE, reader.getPageSize());
+    }
+
+    @Test
+    public void testQuery() throws Exception {
+        reader = buildReader(BATCH, PAGE_SIZE);
+        List<SubSnpGenotype> readSnps = readAll(reader);
+
+        assertEquals(9, readSnps.size());
+        for (SubSnpGenotype expectedSubSnpGenotype : expectedSubSnpGenotyes) {
+            assertContains(readSnps, expectedSubSnpGenotype);
+        }
+    }
+
+    @Test
+    public void testQueryWithDifferentBatch() throws Exception {
+
+        List<SubSnpGenotype> expectedSubSnpGenotyes_case2 = new ArrayList<>();
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+                26011365, "-/-,TAAAAG/TAAAAG,-/-"));
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+                26011366, "-/-,A/A,T/T"));
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+                26011367, "-/-,AT/AT,./."));
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+                26011368, "C/C,T/T,C/C"));
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+                26011369, "A/A,G/G,G/G"));
+
+
+        reader = buildReader(12069, PAGE_SIZE);
+        List<SubSnpGenotype> readSnps = readAll(reader);
+        assertEquals(5, readSnps.size());
+        for (SubSnpGenotype expectedSubSnpGenotype : expectedSubSnpGenotyes_case2) {
+            assertContains(readSnps, expectedSubSnpGenotype);
+        }
+    }
+
+    @Test
+    public void testQueryWithNonExistingBatch() throws Exception {
+        int nonExistingBatch = 42;
+        reader = buildReader(nonExistingBatch, PAGE_SIZE);
+        List<SubSnpGenotype> list = readAll(reader);
+        assertEquals(0, list.size());
+    }
+}

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReaderTest.java
@@ -52,23 +52,23 @@ public class SubSnpGenotypeReaderTest extends ReaderTest {
     public void setUp() {
         expectedSubSnpGenotyes = new ArrayList<>();
 
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505332, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505333, "G/G,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505335, "A/A,C/C"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505336, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505337, "G/G,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505339, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505340, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505342, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "CHICKEN_SNPs_SILKIE",
+        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
                 26505343, "-/-,C/C"));
     }
 
@@ -107,15 +107,15 @@ public class SubSnpGenotypeReaderTest extends ReaderTest {
     public void testQueryWithDifferentBatch() throws Exception {
 
         List<SubSnpGenotype> expectedSubSnpGenotyes_case2 = new ArrayList<>();
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
                 26011365, "-/-,TAAAAG/TAAAAG,-/-"));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
                 26011366, "-/-,A/A,T/T"));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
                 26011367, "-/-,AT/AT,./."));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
                 26011368, "C/C,T/T,C/C"));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "CHICKEN_SNPs_LAYER",
+        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
                 26011369, "A/A,G/G,G/G"));
 
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpGenotypeReaderTest.java
@@ -46,29 +46,29 @@ public class SubSnpGenotypeReaderTest extends ReaderTest {
 
     private SubSnpGenotypeReader reader;
 
-    private List<SubSnpGenotype> expectedSubSnpGenotyes;
+    private List<SubSnpGenotype> expectedSubSnpGenotypes;
 
     @Before
     public void setUp() {
-        expectedSubSnpGenotyes = new ArrayList<>();
+        expectedSubSnpGenotypes = new ArrayList<>();
 
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505332, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505333, "G/G,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505335, "A/A,C/C"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505336, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505337, "G/G,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505339, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505340, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505342, "C/C,T/T"));
-        expectedSubSnpGenotyes.add(new SubSnpGenotype(12068, "12068",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12068, "12068",
                 26505343, "-/-,C/C"));
     }
 
@@ -98,32 +98,33 @@ public class SubSnpGenotypeReaderTest extends ReaderTest {
         List<SubSnpGenotype> readSnps = readAll(reader);
 
         assertEquals(9, readSnps.size());
-        for (SubSnpGenotype expectedSubSnpGenotype : expectedSubSnpGenotyes) {
-            assertContains(readSnps, expectedSubSnpGenotype);
+        for (int i = 0; i < expectedSubSnpGenotypes.size() ; i++) {
+            assertEquals(readSnps.get(i), expectedSubSnpGenotypes.get(i));
         }
     }
 
     @Test
     public void testQueryWithDifferentBatch() throws Exception {
 
-        List<SubSnpGenotype> expectedSubSnpGenotyes_case2 = new ArrayList<>();
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
+        expectedSubSnpGenotypes = new ArrayList<>();
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12069, "12069",
                 26011365, "-/-,TAAAAG/TAAAAG,-/-"));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12069, "12069",
                 26011366, "-/-,A/A,T/T"));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12069, "12069",
                 26011367, "-/-,AT/AT,./."));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12069, "12069",
                 26011368, "C/C,T/T,C/C"));
-        expectedSubSnpGenotyes_case2.add(new SubSnpGenotype(12069, "12069",
+        expectedSubSnpGenotypes.add(new SubSnpGenotype(12069, "12069",
                 26011369, "A/A,G/G,G/G"));
 
 
         reader = buildReader(12069, PAGE_SIZE);
         List<SubSnpGenotype> readSnps = readAll(reader);
         assertEquals(5, readSnps.size());
-        for (SubSnpGenotype expectedSubSnpGenotype : expectedSubSnpGenotyes_case2) {
-            assertContains(readSnps, expectedSubSnpGenotype);
+
+        for (int i = 0; i < expectedSubSnpGenotypes.size(); i++) {
+            assertEquals(readSnps.get(i), expectedSubSnpGenotypes.get(i));
         }
     }
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotypeTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotypeTest.java
@@ -28,18 +28,18 @@ public class SubSnpGenotypeTest {
     public void testSubSnpGenotypeFields() {
         List<String> genotypeList = Arrays.stream("A,A, G".split(",")).map(String::trim)
                 .collect(Collectors.toList());
-        SubSnpGenotype subsnpgenotype = new SubSnpGenotype(14484,"DBSNP.2005.1.20.12.27",
+        SubSnpGenotype subsnpgenotype = new SubSnpGenotype(14484,"14484",
                 32479939, "A,A, G");
         assertEquals(14484, subsnpgenotype.getBatchId());
-        assertEquals("DBSNP.2005.1.20.12.27", subsnpgenotype.getLocBatchId());
+        assertEquals("14484", subsnpgenotype.getStudyId());
         assertEquals(32479939, subsnpgenotype.getSsId());
         assertEquals(genotypeList, subsnpgenotype.getGenotypes());
         assertEquals(3, subsnpgenotype.getGenotypes().size());
 
-        subsnpgenotype = new SubSnpGenotype(2147483647,"DBSNP.2005.1.20.12.27",
+        subsnpgenotype = new SubSnpGenotype(2147483647,"2147483647",
                 9223372036854775807L, "");
         assertEquals(2147483647, subsnpgenotype.getBatchId());
-        assertEquals("DBSNP.2005.1.20.12.27", subsnpgenotype.getLocBatchId());
+        assertEquals("2147483647", subsnpgenotype.getStudyId());
         assertEquals(9223372036854775807L, subsnpgenotype.getSsId());
         assertEquals(0, subsnpgenotype.getGenotypes().size());
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotypeTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotypeTest.java
@@ -26,8 +26,7 @@ public class SubSnpGenotypeTest {
 
     @Test
     public void testSubSnpGenotypeFields() {
-        List<String> genotypeList = Arrays.stream("A,A, G".split(",")).map(String::trim)
-                .collect(Collectors.toList());
+        List<String> genotypeList = Arrays.asList("A", "A", "G");
         SubSnpGenotype subsnpgenotype = new SubSnpGenotype(14484,"14484",
                 32479939, "A,A, G");
         assertEquals(14484, subsnpgenotype.getBatchId());

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotypeTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpGenotypeTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.models;
+
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class SubSnpGenotypeTest {
+
+    @Test
+    public void testSubSnpGenotypeFields() {
+        List<String> genotypeList = Arrays.stream("A,A, G".split(",")).map(String::trim)
+                .collect(Collectors.toList());
+        SubSnpGenotype subsnpgenotype = new SubSnpGenotype(14484,"DBSNP.2005.1.20.12.27",
+                32479939, "A,A, G");
+        assertEquals(14484, subsnpgenotype.getBatchId());
+        assertEquals("DBSNP.2005.1.20.12.27", subsnpgenotype.getLocBatchId());
+        assertEquals(32479939, subsnpgenotype.getSsId());
+        assertEquals(genotypeList, subsnpgenotype.getGenotypes());
+        assertEquals(3, subsnpgenotype.getGenotypes().size());
+
+        subsnpgenotype = new SubSnpGenotype(2147483647,"DBSNP.2005.1.20.12.27",
+                9223372036854775807L, "");
+        assertEquals(2147483647, subsnpgenotype.getBatchId());
+        assertEquals("DBSNP.2005.1.20.12.27", subsnpgenotype.getLocBatchId());
+        assertEquals(9223372036854775807L, subsnpgenotype.getSsId());
+        assertEquals(0, subsnpgenotype.getGenotypes().size());
+    }
+}

--- a/dbsnp-importer/src/test/resources/data.sql
+++ b/dbsnp-importer/src/test/resources/data.sql
@@ -162,3 +162,37 @@ INSERT INTO dbsnp_shared.obsvariation VALUES (20,'G/A','2003-02-22 01:07:00','20
 INSERT INTO dbsnp_shared.obsvariation VALUES (34,'-/G','2003-02-22 01:07:00','2003-07-17 14:33:00',15,NULL,'-/G');
 INSERT INTO dbsnp_shared.obsvariation VALUES (11680,'TCGG/-','2003-04-16 09:16:00','2003-07-17 14:33:00',238,NULL,'TCGG/-');
 INSERT INTO dbsnp_shared.obsvariation VALUES (13946,'TCAGG/-','2003-04-16 15:12:00','2003-07-17 14:33:00',570,NULL,'TCAGG/-');
+
+
+-- gty_id, obs, obs_upp_fix, last_updated_time, load_order
+INSERT INTO dbsnp_shared.obsgenotype VALUES(58, 'T/T', 'T/T', '2003-07-03 16:32:00.000');
+INSERT INTO dbsnp_shared.obsgenotype VALUES(65, 'A/A', 'A/A', '2003-07-03 16:32:00.000');
+INSERT INTO dbsnp_shared.obsgenotype VALUES(86, 'G/G', 'G/G', '2003-07-03 16:32:00.000');
+INSERT INTO dbsnp_shared.obsgenotype VALUES(93, 'C/C', 'C/C', '2003-07-03 16:32:00.000');
+INSERT INTO dbsnp_shared.obsgenotype VALUES(4211, 'TAAAAG/TAAAAG', 'TAAAAG/TAAAAG', '2004-07-20 17:18:00.000');
+
+
+-- batch_id, subsnp_id, genotypes_string
+INSERT INTO subsnpgenotypes VALUES(12068, 26505332, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505333, 'G/G,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505335, 'A/A,C/C');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505336, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505337, 'G/G,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505339, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505340, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505342, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12068, 26505343, '-/-,C/C');
+INSERT INTO subsnpgenotypes VALUES(12069, 26011365, '-/-,TAAAAG/TAAAAG, -/-');
+INSERT INTO subsnpgenotypes VALUES(12069, 26011366, '-/-,A/A,T/T');
+INSERT INTO subsnpgenotypes VALUES(12069, 26011367, '-/-,AT/AT, ./. ');
+INSERT INTO subsnpgenotypes VALUES(12069, 26011368, 'C/C,T/T,C/C');
+INSERT INTO subsnpgenotypes VALUES(12069, 26011369, 'A/A,G/G,G/G');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821291, 'A/A,G/G, A/A');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821292, '-/-,CCC/CCC');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821293, '-/-,CCCCCCC/CCCCCCC');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821294, 'A/A,G/G');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821295, 'A/A,C/C');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821296, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821297, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821298, 'C/C,T/T');
+INSERT INTO subsnpgenotypes VALUES(12070, 24821299, 'A/A,T/T');

--- a/dbsnp-importer/src/test/resources/schema.sql
+++ b/dbsnp-importer/src/test/resources/schema.sql
@@ -2120,6 +2120,12 @@ ALTER TABLE b150_snpcontigloc
 ALTER TABLE b150_snpmapinfo
     ADD CONSTRAINT fk_b150_snpmapinfo_rs FOREIGN KEY (snp_id) REFERENCES snp(snp_id) MATCH FULL;
 
+CREATE TABLE subsnpgenotypes
+(
+    batch_id integer NOT NULL,
+    subsnp_id integer NOT NULL,
+    genotypes_string character varying(1024)
+);
 
 --
 -- Name: dbsnp_shared; Type: SCHEMA; Schema: -; Owner: -
@@ -2139,6 +2145,15 @@ CREATE TABLE dbsnp_shared.obsvariation (
 
 ALTER TABLE dbsnp_shared.obsvariation
     ADD CONSTRAINT dbsnp_shared.obsvariation_pkey PRIMARY KEY (var_id);
+
+CREATE TABLE dbsnp_shared.obsgenotype
+(
+  gty_id integer NOT NULL,
+  obs character varying(512) NOT NULL,
+  obs_upp_fix character varying(512) NOT NULL,
+  last_updated_time timestamp without time zone NOT NULL,
+  CONSTRAINT obsgenotype_pkey PRIMARY KEY (gty_id)
+);
 
 
 --


### PR DESCRIPTION
SubSnpGenotype.java - Class representing SubSNP-genotypes association.
SubSnpGenotypeReader.java - Reader to read SubSNP-genotypes association
from the database.
SubSnpGenotypeRowMapper.java - Map each row representing SubSNP-genotype
association from the database to a SubSnpGenotype object.

data.sql - Added data for the newly added tables.
schema.sql - Updated schema to include a table representation of the
obsgenotype materialized view in Postgres.