### PR TITLE
EVA-971 Retain submitted identifiers in VCFs

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToEvaSubmittedVariantProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToEvaSubmittedVariantProcessor.java
@@ -37,9 +37,10 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessor implements ItemProce
         if (subSnpCoreFields.getRsId() != null) {
             String rsId = "rs" + subSnpCoreFields.getRsId();
             variant.setMainId(rsId);
-            variant.addId(rsId);
+            variant.addDbsnpId(rsId);
         }
-        variant.addId("ss" + subSnpCoreFields.getSsId());
+        String ssId = "ss" + subSnpCoreFields.getSsId();
+        variant.addDbsnpId(ssId);
 
         return variant;
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ImportVariantsStepConfigurationTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ImportVariantsStepConfigurationTest.java
@@ -76,7 +76,7 @@ public class ImportVariantsStepConfigurationTest {
         int totalSubsnps = 0;
         int totalSnps = 0;
         for (DBObject dbObject : dbObjects) {
-            BasicDBList ids = (BasicDBList) dbObject.get("ids");
+            BasicDBList ids = (BasicDBList) dbObject.get("dbsnpIds");
             totalSnps += ids.stream().filter(o -> ((String) o).startsWith("rs")).count();
             totalSubsnps += ids.stream().filter(o -> ((String)o).startsWith("ss")).count();
         }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest.java
@@ -25,6 +25,8 @@ import uk.ac.ebi.eva.dbsnpimporter.models.Orientation;
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 import uk.ac.ebi.eva.dbsnpimporter.test.TestUtils;
 
+import java.util.Set;
+
 import static org.junit.Assert.assertEquals;
 
 public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
@@ -50,7 +52,8 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "T", "A");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
+        variant.setDbsnpIds(ids);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
     }
@@ -65,7 +68,8 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "G");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
+        variant.setDbsnpIds(ids);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
     }
@@ -80,7 +84,8 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "", "A");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
+        variant.setDbsnpIds(ids);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
     }
@@ -95,7 +100,8 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
+        variant.setDbsnpIds(ids);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
     }
@@ -110,7 +116,8 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223963L, "GTA", "T");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
+        variant.setDbsnpIds(ids);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
     }
@@ -119,5 +126,6 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
         assertEquals(variant, processedVariant);
         assertEquals(variant.getMainId(), processedVariant.getMainId());
         assertEquals(variant.getIds(), processedVariant.getIds());
+        assertEquals(variant.getDbsnpIds(), processedVariant.getDbsnpIds());
     }
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessorTest.java
@@ -57,7 +57,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "T", "A");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
         Map<String, String> attributes = Collections.singletonMap(DBSNP_BUILD_KEY, String.valueOf(DBSNP_BUILD));
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[0], null, null,
@@ -77,7 +77,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "G");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
         Map<String, String> attributes = Collections.singletonMap(DBSNP_BUILD_KEY, String.valueOf(DBSNP_BUILD));
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[0], null, null,
@@ -97,7 +97,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "", "A");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
         Map<String, String> attributes = Collections.singletonMap(DBSNP_BUILD_KEY, String.valueOf(DBSNP_BUILD));
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[0], null, null,
@@ -117,7 +117,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
         Map<String, String> attributes = Collections.singletonMap(DBSNP_BUILD_KEY, String.valueOf(DBSNP_BUILD));
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[0], null, null,
@@ -137,7 +137,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, Orientation.FORWARD, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223963L, "GTA", "T");
         variant.setMainId("rs" + 13677177L);
-        variant.setIds(TestUtils.buildIds(26201546L, 13677177L));
+        variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
         Map<String, String> attributes = Collections.singletonMap(DBSNP_BUILD_KEY, String.valueOf(DBSNP_BUILD));
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[]{"GG"}, null,
@@ -151,6 +151,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
         assertEquals(variant, processedVariant);
         assertEquals(variant.getMainId(), processedVariant.getMainId());
         assertEquals(variant.getIds(), processedVariant.getIds());
+        assertEquals(variant.getDbsnpIds(), processedVariant.getDbsnpIds());
 
         assertEquals(1, processedVariant.getSourceEntries().size());
         IVariantSourceEntry sourceEntry = variant.getSourceEntries().iterator().next();


### PR DESCRIPTION
Update the importer with the changes in variation commons about the dbsnpIds. 

Travis will fail until https://github.com/EBIvariation/variation-commons/pull/59 is merged and deployed.