### PR TITLE
EVA-888 Filter out variants with IUPAC codes in allele strings

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/VariantsProcessorConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/VariantsProcessorConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import uk.ac.ebi.eva.commons.core.models.IVariant;
+import uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors.UnambiguousAllelesFilterProcessor;
 import uk.ac.ebi.eva.dbsnpimporter.parameters.Parameters;
 import uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors.MatchingAllelesFilterProcessor;
 import uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors.SubSnpCoreFieldsToEvaSubmittedVariantProcessor;
@@ -49,6 +50,7 @@ public class VariantsProcessorConfiguration {
     ItemProcessor<SubSnpCoreFields, IVariant> subSnpCoreFieldsToVariantProcessor(Parameters parameters) {
         logger.debug("Injecting SubSnpCoreFieldsToVariantProcessor");
         List<ItemProcessor<SubSnpCoreFields, ?>> delegates = Arrays.asList(
+                new UnambiguousAllelesFilterProcessor(),
                 new MatchingAllelesFilterProcessor(),
                 new SubSnpCoreFieldsToVariantProcessor(parameters.getDbsnpBuild()));
         CompositeItemProcessor<SubSnpCoreFields, IVariant> compositeProcessor = new CompositeItemProcessor<>();
@@ -61,6 +63,7 @@ public class VariantsProcessorConfiguration {
     ItemProcessor<SubSnpCoreFields, IVariant> subSnpCoreFieldsToEvaSubmittedVariantProcessor() {
         logger.debug("Injecting SubSnpCoreFieldsToEvaSubmittedVariantProcessor");
         List<ItemProcessor<SubSnpCoreFields, ?>> delegates = Arrays.asList(
+                new UnambiguousAllelesFilterProcessor(),
                 new MatchingAllelesFilterProcessor(),
                 new SubSnpCoreFieldsToEvaSubmittedVariantProcessor());
         CompositeItemProcessor<SubSnpCoreFields, IVariant> compositeProcessor = new CompositeItemProcessor<>();

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessor.java
@@ -21,6 +21,9 @@ import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * Filters out all those variants with IUPAC ambiguity codes in the reference or alternate alleles.
+ */
 public class UnambiguousAllelesFilterProcessor implements ItemProcessor<SubSnpCoreFields, SubSnpCoreFields> {
 
     private Pattern pattern;

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
+
+import org.springframework.batch.item.ItemProcessor;
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class UnambiguousAllelesFilterProcessor implements ItemProcessor<SubSnpCoreFields, SubSnpCoreFields> {
+
+    private Pattern pattern;
+
+    public UnambiguousAllelesFilterProcessor() {
+        pattern = Pattern.compile("[ACGT]*", Pattern.CASE_INSENSITIVE);
+    }
+
+    @Override
+    public SubSnpCoreFields process(SubSnpCoreFields subSnpCoreFields) {
+        Matcher referenceMatcher = pattern.matcher(subSnpCoreFields.getReferenceInForwardStrand());
+        if (!referenceMatcher.matches()) {
+            return null;
+        }
+
+        Matcher alternateMatcher = pattern.matcher(subSnpCoreFields.getAlternateInForwardStrand());
+        if (!alternateMatcher.matches()) {
+            return null;
+        }
+
+        return subSnpCoreFields;
+    }
+
+}

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessorTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
+
+import org.junit.Test;
+import uk.ac.ebi.eva.dbsnpimporter.models.LocusType;
+import uk.ac.ebi.eva.dbsnpimporter.models.Orientation;
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
+
+import static org.junit.Assert.assertNotNull;
+
+public class UnambiguousAllelesFilterProcessorTest {
+
+    private UnambiguousAllelesFilterProcessor filter = new UnambiguousAllelesFilterProcessor();
+
+    @Test
+    public void keepUnambiguousAlleles() {
+        SubSnpCoreFields subSnpCoreFields1 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
+                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
+                1L,1L, "T", "T", "A", "T/A", "NC_006091.4:g.91223961T>A",null, null,
+                Orientation.FORWARD, null, null,null, Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
+                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
+                1L,1L, "T", "TAGC", "A", "TAGC/A", "NC_006091.4:g.91223961T>A", null, null,
+                Orientation.FORWARD, null, null, null, Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
+                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
+                1L,1L, "T", "aCgTAcGt", "AAACCTg", "aCgTAcGt/AAACCTg", "NC_006091.4:g.91223961T>A", null, null,
+                Orientation.FORWARD, null, null, null, Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
+                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
+                1L,1L, "T", "", "ACgt", "/ACgt", "NC_006091.4:g.91223961T>A", null, null,
+                Orientation.FORWARD, null, null, null, Orientation.FORWARD, "batch");
+
+        assertNotNull(filter.process(subSnpCoreFields1));
+        assertNotNull(filter.process(subSnpCoreFields2));
+        assertNotNull(filter.process(subSnpCoreFields3));
+        assertNotNull(filter.process(subSnpCoreFields4));
+    }
+
+    @Test
+    public void removeAmbiguousReferenceAllele() {
+
+    }
+
+    @Test
+    public void removeAmbiguousAlternateAllele() {
+
+    }
+}

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessorTest.java
@@ -16,11 +16,13 @@
 package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
 
 import org.junit.Test;
+
 import uk.ac.ebi.eva.dbsnpimporter.models.LocusType;
 import uk.ac.ebi.eva.dbsnpimporter.models.Orientation;
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class UnambiguousAllelesFilterProcessorTest {
 
@@ -28,25 +30,30 @@ public class UnambiguousAllelesFilterProcessorTest {
 
     @Test
     public void keepUnambiguousAlleles() {
-        SubSnpCoreFields subSnpCoreFields1 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
-                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
-                1L,1L, "T", "T", "A", "T/A", "NC_006091.4:g.91223961T>A",null, null,
-                Orientation.FORWARD, null, null,null, Orientation.FORWARD, "batch");
+        SubSnpCoreFields subSnpCoreFields1 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "T", "T", "A", "T/A", "",
+                                                                  null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
 
-        SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
-                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
-                1L,1L, "T", "TAGC", "A", "TAGC/A", "NC_006091.4:g.91223961T>A", null, null,
-                Orientation.FORWARD, null, null, null, Orientation.FORWARD, "batch");
+        SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "TAGC", "TAGC", "A",
+                                                                  "TAGC/A", "", null, null, Orientation.FORWARD, null,
+                                                                  null, null, Orientation.FORWARD, "batch");
 
-        SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
-                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
-                1L,1L, "T", "aCgTAcGt", "AAACCTg", "aCgTAcGt/AAACCTg", "NC_006091.4:g.91223961T>A", null, null,
-                Orientation.FORWARD, null, null, null, Orientation.FORWARD, "batch");
+        SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "aCgTAcGt", "aCgTAcGt",
+                                                                  "AAACCTg", "aCgTAcGt/AAACCTg", "", null, null,
+                                                                  Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
 
-        SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L,
-                Orientation.FORWARD, "NT_455866.1",1L, 1L, Orientation.FORWARD, LocusType.SNP, "4",
-                1L,1L, "T", "", "ACgt", "/ACgt", "NC_006091.4:g.91223961T>A", null, null,
-                Orientation.FORWARD, null, null, null, Orientation.FORWARD, "batch");
+        SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "", "", "ACgt", "/ACgt",
+                                                                  "", null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
 
         assertNotNull(filter.process(subSnpCoreFields1));
         assertNotNull(filter.process(subSnpCoreFields2));
@@ -56,11 +63,67 @@ public class UnambiguousAllelesFilterProcessorTest {
 
     @Test
     public void removeAmbiguousReferenceAllele() {
+        SubSnpCoreFields subSnpCoreFields1 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "N", "N", "A", "N/A", "",
+                                                                  null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
 
+        SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "AGYT", "AGYT", "A",
+                                                                  "AGYT/A", "", null, null, Orientation.FORWARD, null,
+                                                                  null, null, Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "rxyz", "rxyz",
+                                                                  "AAACCTg", "rxyz/AAACCTg", "", null, null,
+                                                                  Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "y", "y", "ACg", "y/ACg",
+                                                                  "", null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
+
+        assertNull(filter.process(subSnpCoreFields1));
+        assertNull(filter.process(subSnpCoreFields2));
+        assertNull(filter.process(subSnpCoreFields3));
+        assertNull(filter.process(subSnpCoreFields4));
     }
 
     @Test
     public void removeAmbiguousAlternateAllele() {
+        SubSnpCoreFields subSnpCoreFields1 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "A", "A", "N", "A/N", "",
+                                                                  null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
 
+        SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "A", "A", "AGYT",
+                                                                  "A/AGYT", "", null, null, Orientation.FORWARD, null,
+                                                                  null, null, Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "AAACCTg", "AAACCTg",
+                                                                  "rxyz", "AAACCTg/rxyz", "", null, null,
+                                                                  Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
+
+        SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "Ag", "Ag", "y", "y/Ag",
+                                                                  "", null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
+
+        assertNull(filter.process(subSnpCoreFields1));
+        assertNull(filter.process(subSnpCoreFields2));
+        assertNull(filter.process(subSnpCoreFields3));
+        assertNull(filter.process(subSnpCoreFields4));
     }
 }


### PR DESCRIPTION
Variants with IUPAC ambiguity codes either in the reference or alternates alleles must be filtered out. A new processor has been implemented and added to the composite processor.