### PR TITLE
EVA-974 Filter out variants with no contig or chromosome coordinates

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/VariantsProcessorConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/VariantsProcessorConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import uk.ac.ebi.eva.commons.core.models.IVariant;
+import uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors.MissingCoordinatesFilterProcessor;
 import uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors.UnambiguousAllelesFilterProcessor;
 import uk.ac.ebi.eva.dbsnpimporter.parameters.Parameters;
 import uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors.MatchingAllelesFilterProcessor;
@@ -50,6 +51,7 @@ public class VariantsProcessorConfiguration {
     ItemProcessor<SubSnpCoreFields, IVariant> subSnpCoreFieldsToVariantProcessor(Parameters parameters) {
         logger.debug("Injecting SubSnpCoreFieldsToVariantProcessor");
         List<ItemProcessor<SubSnpCoreFields, ?>> delegates = Arrays.asList(
+                new MissingCoordinatesFilterProcessor(),
                 new UnambiguousAllelesFilterProcessor(),
                 new MatchingAllelesFilterProcessor(),
                 new SubSnpCoreFieldsToVariantProcessor(parameters.getDbsnpBuild()));
@@ -63,6 +65,7 @@ public class VariantsProcessorConfiguration {
     ItemProcessor<SubSnpCoreFields, IVariant> subSnpCoreFieldsToEvaSubmittedVariantProcessor() {
         logger.debug("Injecting SubSnpCoreFieldsToEvaSubmittedVariantProcessor");
         List<ItemProcessor<SubSnpCoreFields, ?>> delegates = Arrays.asList(
+                new MissingCoordinatesFilterProcessor(),
                 new UnambiguousAllelesFilterProcessor(),
                 new MatchingAllelesFilterProcessor(),
                 new SubSnpCoreFieldsToEvaSubmittedVariantProcessor());

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
+
+import org.springframework.batch.item.ItemProcessor;
+
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
+
+/**
+ * Filters out those variants without coordinates in a chromosome *or* contig.
+ */
+public class MissingCoordinatesFilterProcessor implements ItemProcessor<SubSnpCoreFields, SubSnpCoreFields> {
+
+    @Override
+    public SubSnpCoreFields process(SubSnpCoreFields subSnpCoreFields) {
+        if (subSnpCoreFields.getVariantCoordinates() == null) {
+            return null;
+        }
+
+        return subSnpCoreFields;
+    }
+
+}

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
@@ -108,7 +108,7 @@ public class SubSnpCoreFields {
                             String hgvsTString, Long hgvsTStart, Long hgvsTStop, Orientation hgvsTOrientation,
                             String batch) {
 
-        if (contigStart < 0 || contigEnd < 0) {
+        if ((contigStart != null && contigStart < 0) || (contigEnd != null && contigEnd < 0)) {
             throw new IllegalArgumentException("Contig coordinates must be non-negative numbers");
         }
         if ((chromosomeStart != null && chromosomeStart < 0) || (chromosomeEnd != null && chromosomeEnd < 0)) {
@@ -400,7 +400,7 @@ public class SubSnpCoreFields {
             throw new IllegalArgumentException("dbSNP variants without coordinates are not valid EVA variants");
         }
         return new VariantCoreFields(variantRegion.getChromosome(), variantRegion.getStart(),
-                                    getReferenceInForwardStrand(), getAlternateInForwardStrand());
+                                     getReferenceInForwardStrand(), getAlternateInForwardStrand());
     }
 
     @Override

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
@@ -68,7 +68,7 @@ public class MissingCoordinatesFilterProcessorTest {
     public void removeStartCoordinatesMissing() {
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                  "NT_455866.1", null, 1L, Orientation.FORWARD,
-                                                                 LocusType.SNP, "4", 1L, null, "T", "T", "A", "T/A", "",
+                                                                 LocusType.SNP, "4", null, 1L, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
                                                                  Orientation.FORWARD, "batch");
         assertNull(filter.process(subSnpCoreFields));
@@ -78,7 +78,7 @@ public class MissingCoordinatesFilterProcessorTest {
     public void removeEndCoordinatesMissing() {
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                  "NT_455866.1", 1L, null, Orientation.FORWARD,
-                                                                 LocusType.SNP, "4", null, 1L, "T", "T", "A", "T/A", "",
+                                                                 LocusType.SNP, "4", 1L, null, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
                                                                  Orientation.FORWARD, "batch");
         assertNull(filter.process(subSnpCoreFields));

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
@@ -24,7 +24,6 @@ import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 public class MissingCoordinatesFilterProcessorTest {
 
@@ -63,6 +62,36 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                  null, null, Orientation.FORWARD, null, null, null,
                                                                  Orientation.FORWARD, "batch");
         assertNotNull(filter.process(subSnpCoreFields));
+    }
+
+    @Test
+    public void removeStartCoordinatesMissing() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                 "NT_455866.1", null, 1L, Orientation.FORWARD,
+                                                                 LocusType.SNP, "4", 1L, null, "T", "T", "A", "T/A", "",
+                                                                 null, null, Orientation.FORWARD, null, null, null,
+                                                                 Orientation.FORWARD, "batch");
+        assertNull(filter.process(subSnpCoreFields));
+    }
+
+    @Test
+    public void removeEndCoordinatesMissing() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                 "NT_455866.1", 1L, null, Orientation.FORWARD,
+                                                                 LocusType.SNP, "4", null, 1L, "T", "T", "A", "T/A", "",
+                                                                 null, null, Orientation.FORWARD, null, null, null,
+                                                                 Orientation.FORWARD, "batch");
+        assertNull(filter.process(subSnpCoreFields));
+    }
+
+    @Test
+    public void removeAllCoordinatesMissing() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                 "NT_455866.1", null, null, Orientation.FORWARD,
+                                                                 LocusType.SNP, "4", null, null, "T", "T", "A", "T/A", "",
+                                                                 null, null, Orientation.FORWARD, null, null, null,
+                                                                 Orientation.FORWARD, "batch");
+        assertNull(filter.process(subSnpCoreFields));
     }
 
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 EMBL - European Bioinformatics Institute
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import uk.ac.ebi.eva.dbsnpimporter.models.LocusType;
+import uk.ac.ebi.eva.dbsnpimporter.models.Orientation;
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class MissingCoordinatesFilterProcessorTest {
+
+    private MissingCoordinatesFilterProcessor filter;
+
+    @Before
+    public void setUp() {
+        filter = new MissingCoordinatesFilterProcessor();
+    }
+
+    @Test
+    public void keepAllCoordinatesPresent() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                 "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                 LocusType.SNP, "4", 1L, 1L, "T", "T", "A", "T/A", "",
+                                                                 null, null, Orientation.FORWARD, null, null, null,
+                                                                 Orientation.FORWARD, "batch");
+        assertNotNull(filter.process(subSnpCoreFields));
+    }
+
+    @Test
+    public void keepChromosomeCoordinatesPresent() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                  "NT_455866.1", null, null, Orientation.FORWARD,
+                                                                  LocusType.SNP, "4", 1L, 1L, "T", "T", "A", "T/A", "",
+                                                                  null, null, Orientation.FORWARD, null, null, null,
+                                                                  Orientation.FORWARD, "batch");
+        assertNotNull(filter.process(subSnpCoreFields));
+    }
+
+    @Test
+    public void keepContigCoordinatesPresent() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
+                                                                 "NT_455866.1", 1L, 1L, Orientation.FORWARD,
+                                                                 LocusType.SNP, "4", null, null, "T", "T", "A", "T/A", "",
+                                                                 null, null, Orientation.FORWARD, null, null, null,
+                                                                 Orientation.FORWARD, "batch");
+        assertNotNull(filter.process(subSnpCoreFields));
+    }
+
+}

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
@@ -73,6 +73,21 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
+    public void testWithoutContigCoordinates() {
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(12345, Orientation.FORWARD, 123L, Orientation.FORWARD,
+                                                                 "contigName", null, null, Orientation.REVERSE,
+                                                                 LocusType.SNP, "chromosomeName", 1L, 10L,"T", "T",
+                                                                 "A", "T/A", "", null, null, Orientation.FORWARD, "",
+                                                                 null, null, Orientation.FORWARD, "batch");
+
+        assertEquals(12345, subSnpCoreFields.getSsId());
+        assertEquals(Orientation.FORWARD, subSnpCoreFields.getSnpOrientation());
+        assertEquals(new Region("contigName"), subSnpCoreFields.getContigRegion());
+        assertEquals(Orientation.REVERSE, subSnpCoreFields.getContigOrientation());
+        assertEquals(new Region("chromosomeName", 1L, 10L), subSnpCoreFields.getChromosomeRegion());
+    }
+
+    @Test
     public void testRsIdDefinition() {
         SubSnpCoreFields subSnpCoreFields1 = new SubSnpCoreFields(1, Orientation.FORWARD, 123L, Orientation.FORWARD,
                                                                   "contigName", 1L, 10L, Orientation.REVERSE,


### PR DESCRIPTION
Implemented new processor that filters out variants without reported coordinates. This check was previously implemented in the `SubSnpCoreFields` constructor but that wasn't correct because the "legacy" accession tracker should accept those.