### PR TITLE
EVA-946 Ordering query results by RefSNP instead of SubSNP ID

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -178,7 +178,7 @@ public class SubSnpCoreFieldsReader extends JdbcCursorItemReader<SubSnpCoreField
                         "ctg.group_term IN (?) AND " +
                         "ctg.group_label LIKE ?" +
                 " ORDER BY " +
-                        SUBSNP_ID_COLUMN;
+                        REFSNP_ID_COLUMN;
 
         return sql;
     }


### PR DESCRIPTION
Ordering query results by RefSNP ID halves the time required to execute the variant import.