### PR TITLE
EVA-431 Read contig aliases: bugfix

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/parameters/Parameters.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/parameters/Parameters.java
@@ -122,6 +122,10 @@ public class Parameters implements InitializingBean {
         return contigMappingUrl;
     }
 
+    public void setContigMappingUrl(String contigMappingUrl) {
+        this.contigMappingUrl = contigMappingUrl;
+    }
+
     @Override
     public String toString() {
         return "Parameters{" +


### PR DESCRIPTION
For spring to put properties in our `@ConfigurationProperties` beans, the beans need setters.

without this, the job fails because the path to the mapping file is null. 