### PR TITLE
EVA-1015 Improve logging to show times around the query

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ImportVariantsStepConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ImportVariantsStepConfiguration.java
@@ -17,10 +17,14 @@ package uk.ac.ebi.eva.dbsnpimporter.configuration;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.ChunkListener;
+import org.springframework.batch.core.ItemReadListener;
 import org.springframework.batch.core.ItemWriteListener;
 import org.springframework.batch.core.Step;
+import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.batch.core.configuration.annotation.StepBuilderFactory;
+import org.springframework.batch.core.listener.StepListenerSupport;
 import org.springframework.batch.item.ItemProcessor;
 import org.springframework.batch.item.ItemStreamReader;
 import org.springframework.batch.item.ItemWriter;
@@ -64,7 +68,7 @@ public class ImportVariantsStepConfiguration {
     private ItemWriter<IVariant> writer;
 
     @Autowired
-    private ItemWriteListener<IVariant> writeLogger;
+    private StepListenerSupport<SubSnpCoreFields, IVariant> listenerLogger;
 
     @Bean
     public SimpleCompletionPolicy chunkSizecompletionPolicy(Parameters parameters) {
@@ -81,7 +85,10 @@ public class ImportVariantsStepConfiguration {
                 .reader(reader)
                 .processor(processor)
                 .writer(writer)
-                .listener(writeLogger)
+                .listener((StepExecutionListener) listenerLogger)
+                .listener((ChunkListener) listenerLogger)
+                .listener((ItemReadListener) listenerLogger)
+                .listener((ItemWriteListener) listenerLogger)
                 .build();
     }
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ListenersConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ListenersConfiguration.java
@@ -65,7 +65,7 @@ public class ListenersConfiguration {
         @Override
         public void beforeRead() {
             if (numItemsRead % parameters.getChunkSize() == 0) {
-                logger.debug("About to read element {}", numItemsRead);
+                logger.debug("About to read item {}", numItemsRead);
             }
             numItemsRead++;
         }
@@ -73,20 +73,20 @@ public class ListenersConfiguration {
         @Override
         public void afterRead(SubSnpCoreFields item) {
             if (numItemsRead % parameters.getChunkSize() == 0) {
-                logger.debug("Element {} was read", numItemsRead);
+                logger.debug("Read {} items", numItemsRead);
             }
         }
 
         @Override
         public void beforeWrite(List<? extends IVariant> items) {
-            logger.debug("About to write a chunk");
+            logger.debug("About to write chunk");
         }
 
         @Override
         public void afterWrite(List<? extends IVariant> items) {
-            IVariant lastElement = items.get(items.size() - 1);
-            logger.debug("Wrote a chunk of {} elements. Last element was {}: {}", items.size(),
-                         lastElement.getMainId(), lastElement);
+            IVariant lastItem = items.get(items.size() - 1);
+            logger.debug("Written chunk of {} items. Last item was {}: {}", items.size(), lastItem.getMainId(),
+                         lastItem);
         }
 
         @Override

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ListenersConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ListenersConfiguration.java
@@ -45,16 +45,16 @@ public class ListenersConfiguration {
 
         private Parameters parameters;
 
-        private StepExecution stepExecution;
+        private long itemsRead;
 
         public writerListener(Parameters parameters) {
             this.parameters = parameters;
+            this.itemsRead = 0;
         }
 
         @Override
         public void beforeStep(StepExecution stepExecution) {
             logger.info("Starting a step");
-            this.stepExecution = stepExecution;
         }
 
         @Override
@@ -64,15 +64,16 @@ public class ListenersConfiguration {
 
         @Override
         public void beforeRead() {
-            if (stepExecution.getReadCount() % parameters.getChunkSize() == 0) {
+            if (itemsRead % parameters.getChunkSize() == 0) {
                 logger.info("About to read element (this log appears once every {} elements read)",
                             parameters.getChunkSize());
             }
+            itemsRead++;
         }
 
         @Override
         public void afterRead(SubSnpCoreFields item) {
-            if (stepExecution.getReadCount() % parameters.getChunkSize() == 0) {
+            if (itemsRead % parameters.getChunkSize() == 0) {
                 logger.info("Element was read (this log appears once every {} elements read)",
                             parameters.getChunkSize());
             }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/contig/RefseqAssemblyReportParser.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/contig/RefseqAssemblyReportParser.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.ebi.eva.dbsnpimporter.contig;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ExecutionContext;
 import org.springframework.batch.item.file.FlatFileItemReader;
 import org.springframework.batch.item.file.mapping.PassThroughLineMapper;
@@ -25,6 +27,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class RefseqAssemblyReportParser {
+
+    private static final Logger logger = LoggerFactory.getLogger(RefseqAssemblyReportParser.class);
 
     private static final int GENBANK_COLUMN = 4;
 
@@ -48,7 +52,7 @@ public class RefseqAssemblyReportParser {
         try {
             reader.setResource(new UrlResource(url));
         } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("File location is invalid: " + url, e);
+            throw new IllegalArgumentException("Contig mapping file location is invalid: " + url, e);
         }
         reader.setLineMapper(new PassThroughLineMapper());
         reader.open(new ExecutionContext());
@@ -56,12 +60,16 @@ public class RefseqAssemblyReportParser {
 
     public Map<String, String> getContigMap() throws Exception {
         if (contigMap == null) {
+            logger.debug("About to populate contig mapping");
+
             String line;
             contigMap = new HashMap<>();
             while ((line = reader.read()) != null) {
                 addContigSynonym(line, contigMap);
             }
             reader.close();
+
+            logger.debug("Contig mapping populated");
         }
         return contigMap;
     }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MatchingAllelesFilterProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MatchingAllelesFilterProcessor.java
@@ -15,11 +15,15 @@
  */
 package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 
 public class MatchingAllelesFilterProcessor implements ItemProcessor<SubSnpCoreFields, SubSnpCoreFields> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MatchingAllelesFilterProcessor.class);
 
     @Override
     public SubSnpCoreFields process(SubSnpCoreFields subSnpCoreFields) throws Exception {
@@ -35,6 +39,7 @@ public class MatchingAllelesFilterProcessor implements ItemProcessor<SubSnpCoreF
             }
         }
         if (!referenceMatches) {
+            logger.debug("Variant filtered out because reference allele is not in alleles list: {}", subSnpCoreFields);
             return null;
         }
 
@@ -47,8 +52,10 @@ public class MatchingAllelesFilterProcessor implements ItemProcessor<SubSnpCoreF
             }
         }
         if (!alternateMatches) {
+            logger.debug("Variant filtered out because alternate allele is not in alleles list: {}", subSnpCoreFields);
             return null;
         }
+
         return subSnpCoreFields;
     }
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessor.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
@@ -24,9 +26,12 @@ import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
  */
 public class MissingCoordinatesFilterProcessor implements ItemProcessor<SubSnpCoreFields, SubSnpCoreFields> {
 
+    private static final Logger logger = LoggerFactory.getLogger(MissingCoordinatesFilterProcessor.class);
+
     @Override
     public SubSnpCoreFields process(SubSnpCoreFields subSnpCoreFields) {
         if (subSnpCoreFields.getVariantCoordinates() == null) {
+            logger.debug("Variant filtered out because it does not have a genomic location: {}", subSnpCoreFields);
             return null;
         }
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessor.java
@@ -15,6 +15,8 @@
  */
 package uk.ac.ebi.eva.dbsnpimporter.jobs.steps.processors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.batch.item.ItemProcessor;
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
 
@@ -26,6 +28,8 @@ import java.util.regex.Pattern;
  */
 public class UnambiguousAllelesFilterProcessor implements ItemProcessor<SubSnpCoreFields, SubSnpCoreFields> {
 
+    private static final Logger logger = LoggerFactory.getLogger(UnambiguousAllelesFilterProcessor.class);
+
     private Pattern pattern;
 
     public UnambiguousAllelesFilterProcessor() {
@@ -36,11 +40,13 @@ public class UnambiguousAllelesFilterProcessor implements ItemProcessor<SubSnpCo
     public SubSnpCoreFields process(SubSnpCoreFields subSnpCoreFields) {
         Matcher referenceMatcher = pattern.matcher(subSnpCoreFields.getReferenceInForwardStrand());
         if (!referenceMatcher.matches()) {
+            logger.debug("Variant filtered out because reference allele is ambiguous: {}", subSnpCoreFields);
             return null;
         }
 
         Matcher alternateMatcher = pattern.matcher(subSnpCoreFields.getAlternateInForwardStrand());
         if (!alternateMatcher.matches()) {
+            logger.debug("Variant filtered out because alternate allele is ambiguous: {}", subSnpCoreFields);
             return null;
         }
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
@@ -29,6 +29,8 @@ import java.util.stream.Stream;
  */
 public class SubSnpCoreFields {
 
+    private String batch;
+
     private long ssId;
 
     private Long rsId;
@@ -68,8 +70,6 @@ public class SubSnpCoreFields {
     private Long hgvsTStop;
 
     private Orientation hgvsTOrientation;
-
-    private String batch;
 
     /**
      * @param subSnpId          Unique SS ID identifier
@@ -469,27 +469,12 @@ public class SubSnpCoreFields {
     @Override
     public String toString() {
         return "SubSnpCoreFields{" +
-                "ssId=" + ssId +
+                "batch='" + batch + '\'' +
+                ", ssId=" + ssId +
                 ", rsId=" + rsId +
-                ", locusType=" + locusType +
-                ", contigRegion=" + contigRegion +
-                ", chromosomeRegion=" + chromosomeRegion +
-                ", snpOrientation=" + snpOrientation +
-                ", contigOrientation=" + contigOrientation +
-                ", hgvsCReference='" + hgvsCReference + '\'' +
-                ", hgvsTReference='" + hgvsTReference + '\'' +
-                ", alternate='" + alternate + '\'' +
+                ", reference='" + getReferenceInForwardStrand() + '\'' +
+                ", alternate='" + getAlternateInForwardStrand() + '\'' +
                 ", alleles='" + alleles + '\'' +
-                ", subSnpOrientation=" + subSnpOrientation +
-                ", hgvsCString='" + hgvsCString + '\'' +
-                ", hgvsCStart=" + hgvsCStart +
-                ", hgvsCStop=" + hgvsCStop +
-                ", hgvsCOrientation=" + hgvsCOrientation +
-                ", hgvsTString='" + hgvsTString + '\'' +
-                ", hgvsTStart=" + hgvsTStart +
-                ", hgvsTStop=" + hgvsTStop +
-                ", hgvsTOrientation=" + hgvsTOrientation +
-                ", batch='" + batch + '\'' +
                 '}';
     }
 }


### PR DESCRIPTION
Add more logging to see where exactly are the delays, whether it's before, during or after receiving the elements in the reader part of the step.

I'm using a manual count because the readCount in the stepExecution is not updated within a batch.