### PR TITLE
EVA-883 - Read genotypes for an SS and map to EVA model

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -27,7 +27,33 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.*;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.ALLELES;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.ALTERNATE;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.BATCH_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CHROMOSOME_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CHROMOSOME_END_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CHROMOSOME_START_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_END_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_NAME_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_ORIENTATION_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_START_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_ORIENTATION;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_START;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_STOP;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_STRING;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_ORIENTATION;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_START;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_STOP;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_STRING;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.LOAD_ORDER_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.LOC_TYPE_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.REFERENCE_C;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.REFERENCE_T;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.REFSNP_ID_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.SNP_ORIENTATION_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.SUBSNP_ID_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.SUBSNP_ORIENTATION_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.GENOTYPES_COLUMN;
 
 /**
     SELECT

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReader.java
@@ -27,32 +27,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.ALLELES;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.ALTERNATE;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.BATCH_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CHROMOSOME_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CHROMOSOME_END_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CHROMOSOME_START_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_END_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_NAME_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_ORIENTATION_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.CONTIG_START_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_ORIENTATION;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_START;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_STOP;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_C_STRING;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_ORIENTATION;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_START;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_STOP;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.HGVS_T_STRING;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.LOAD_ORDER_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.LOC_TYPE_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.REFERENCE_C;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.REFERENCE_T;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.REFSNP_ID_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.SNP_ORIENTATION_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.SUBSNP_ID_COLUMN;
-import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.SUBSNP_ORIENTATION_COLUMN;
+import static uk.ac.ebi.eva.dbsnpimporter.io.readers.SubSnpCoreFieldsRowMapper.*;
 
 /**
     SELECT
@@ -114,6 +89,7 @@ public class SubSnpCoreFieldsReader extends JdbcCursorItemReader<SubSnpCoreField
                         "," + HGVS_T_START +
                         "," + HGVS_T_STOP +
                         "," + HGVS_T_ORIENTATION +
+                        "," + GENOTYPES_COLUMN +
                         "," + BATCH_COLUMN +
                         " FROM " + tableName +
                         " WHERE batch_id = ? " +

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsRowMapper.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsRowMapper.java
@@ -83,6 +83,8 @@ public class SubSnpCoreFieldsRowMapper implements RowMapper<SubSnpCoreFields> {
 
     public static final String LOAD_ORDER_COLUMN = "load_order";
 
+    public static final String GENOTYPES_COLUMN = "genotypes_string";
+
     private ResultSet resultSet;
 
     /**
@@ -121,6 +123,7 @@ public class SubSnpCoreFieldsRowMapper implements RowMapper<SubSnpCoreFields> {
                 getAsLong(HGVS_T_START),
                 getAsLong(HGVS_T_STOP),
                 Orientation.getOrientation(resultSet.getInt(HGVS_T_ORIENTATION)),
+                resultSet.getString(GENOTYPES_COLUMN),
                 resultSet.getString(BATCH_COLUMN));
     }
 

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessor.java
@@ -42,6 +42,7 @@ public class SubSnpCoreFieldsToVariantProcessor extends SubSnpCoreFieldsToEvaSub
                                                                        subSnpCoreFields.getBatch());
         variantSourceEntry.addAttribute(DBSNP_BUILD_KEY, dbsnpBuild);
         variantSourceEntry.setSecondaryAlternates(subSnpCoreFields.getSecondaryAlternatesInForwardStrand());
+        subSnpCoreFields.getGenotypeList().forEach(variantSourceEntry::addSampleData);
         variant.addSourceEntry(variantSourceEntry);
 
         return variant;

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessor.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessor.java
@@ -42,7 +42,7 @@ public class SubSnpCoreFieldsToVariantProcessor extends SubSnpCoreFieldsToEvaSub
                                                                        subSnpCoreFields.getBatch());
         variantSourceEntry.addAttribute(DBSNP_BUILD_KEY, dbsnpBuild);
         variantSourceEntry.setSecondaryAlternates(subSnpCoreFields.getSecondaryAlternatesInForwardStrand());
-        subSnpCoreFields.getGenotypeList().forEach(variantSourceEntry::addSampleData);
+        subSnpCoreFields.getGenotypes().forEach(variantSourceEntry::addSampleData);
         variant.addSourceEntry(variantSourceEntry);
 
         return variant;

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
@@ -17,10 +17,10 @@ package uk.ac.ebi.eva.dbsnpimporter.models;
 
 import uk.ac.ebi.eva.commons.core.models.Region;
 import uk.ac.ebi.eva.commons.core.models.VariantCoreFields;
+import uk.ac.ebi.eva.commons.core.models.genotype.Genotype;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -71,6 +71,8 @@ public class SubSnpCoreFields {
 
     private Orientation hgvsTOrientation;
 
+    private List<Map<String, String>> genotypeList;
+
     /**
      * @param subSnpId          Unique SS ID identifier
      * @param subSnpOrientation Orientation of the ssid to the rsid (1 for forward, -1 for reverse)
@@ -98,6 +100,7 @@ public class SubSnpCoreFields {
      * @param hgvsTStart        start of the variant in a contig according to HGVS
      * @param hgvsTStop         end of the variant in a contig according to HGVS
      * @param hgvsTOrientation  Orientation of the contig to the chromosome (1 for forward, -1 for reverse)
+     * @param genotypes         Genotypes associated with a given SNP in a given batch in a comma-separated list (ex: "C/T,T/T")
      * @param batch             name of the submitted batch to dbSNP, from the column loc_batch_id_upp (similar to study name)
      */
     public SubSnpCoreFields(long subSnpId, Orientation subSnpOrientation, Long snpId, Orientation snpOrientation,
@@ -106,7 +109,7 @@ public class SubSnpCoreFields {
                             String hgvsCReference, String hgvsTReference, String alternate, String alleles,
                             String hgvsCString, Long hgvsCStart, Long hgvsCStop, Orientation hgvsCOrientation,
                             String hgvsTString, Long hgvsTStart, Long hgvsTStop, Orientation hgvsTOrientation,
-                            String batch) {
+                            String genotypes, String batch) {
 
         if ((contigStart != null && contigStart < 0) || (contigEnd != null && contigEnd < 0)) {
             throw new IllegalArgumentException("Contig coordinates must be non-negative numbers");
@@ -135,7 +138,38 @@ public class SubSnpCoreFields {
         this.hgvsTStart = hgvsTStart;
         this.hgvsTStop = hgvsTStop;
         this.hgvsTOrientation = hgvsTOrientation;
+        this.genotypeList = getGenotypeListFromString(genotypes);
         this.batch = batch;
+    }
+
+    private List<Map<String, String>> getGenotypeListFromString (String genotypes_string) {
+        if (genotypes_string != null && !genotypes_string.isEmpty()) {
+            boolean alleleOrientation = getAlleleOrientation();
+            String ref = getReferenceInForwardStrand();
+            String alt = getAlternateInForwardStrand();
+            return Arrays.stream(genotypes_string.split(",", -1))
+                    .map(String::trim)
+                    .map(genotypeString -> getForwardOrientedGenotype(alleleOrientation, genotypeString))
+                    .map(genotypeString -> getGenotypeMapFromString(genotypeString, ref, alt))
+                    .collect(Collectors.toList());
+        }
+        return new ArrayList<>();
+    }
+
+    private String getForwardOrientedGenotype(boolean forward, String genotypeString) {
+        Pattern genotypePattern = Pattern.compile("/|\\|");
+        String outputDelimiterToUse = genotypeString.contains("|") ? "|" : "/";
+
+        return Arrays.stream(genotypePattern.split(genotypeString, -1))
+                .map(String::trim)
+                .map(alleles -> getForwardOrientedAllele(forward, alleles))
+                .collect(Collectors.joining(outputDelimiterToUse));
+    }
+
+    private Map<String, String> getGenotypeMapFromString (String genotypeString, String ref, String alt) {
+        Map<String, String> genotypeMap = new HashMap<>();
+        genotypeMap.put("GT", new Genotype(genotypeString, ref, alt).toString());
+        return genotypeMap;
     }
 
     private Region createRegion(String sequenceName, Long start, Long end) {
@@ -236,6 +270,14 @@ public class SubSnpCoreFields {
         return hgvsTOrientation;
     }
 
+    public List<Map<String, String>> getGenotypeList() {
+        return genotypeList;
+    }
+
+    public void setGenotypeList(String genotypeList) {
+        this.genotypeList = getGenotypeListFromString(genotypeList);
+    }
+
     public String getBatch() {
         return batch;
     }
@@ -306,15 +348,19 @@ public class SubSnpCoreFields {
      * - rs10721689 :  "alleles" are reverse when orientations are 1 -1 1, forward when 1 -1 -1
      */
     public String getAllelesInForwardStrand() {
-        boolean forward = this.getSubSnpOrientation().equals(Orientation.FORWARD)
-                ^ this.getSnpOrientation().equals(Orientation.FORWARD)
-                ^ this.getContigOrientation().equals(Orientation.FORWARD);
+        return getForwardOrientedAllele(getAlleleOrientation(), this.getAlleles());
+    }
 
-        String alleles = this.getAlleles();
+    private String getForwardOrientedAllele(boolean forward, String alleles) {
         String forwardAlleles = forward ? alleles : calculateReverseComplement(alleles);
-
         String[] splitAlleles = forwardAlleles.split("/", -1);
         return Stream.of(splitAlleles).map(this::getTrimmedAllele).collect(Collectors.joining("/"));
+    }
+
+    private boolean getAlleleOrientation() {
+        return this.getSubSnpOrientation().equals(Orientation.FORWARD)
+                    ^ this.getSnpOrientation().equals(Orientation.FORWARD)
+                    ^ this.getContigOrientation().equals(Orientation.FORWARD);
     }
 
     public String[] getSecondaryAlternatesInForwardStrand() {
@@ -437,6 +483,7 @@ public class SubSnpCoreFields {
         if (hgvsTStart != null ? !hgvsTStart.equals(that.hgvsTStart) : that.hgvsTStart != null) return false;
         if (hgvsTStop != null ? !hgvsTStop.equals(that.hgvsTStop) : that.hgvsTStop != null) return false;
         if (hgvsTOrientation != that.hgvsTOrientation) return false;
+        if (!genotypeList.equals(that.genotypeList)) return false;
         return batch != null ? batch.equals(that.batch) : that.batch == null;
     }
 
@@ -462,6 +509,7 @@ public class SubSnpCoreFields {
         result = 31 * result + (hgvsTStart != null ? hgvsTStart.hashCode() : 0);
         result = 31 * result + (hgvsTStop != null ? hgvsTStop.hashCode() : 0);
         result = 31 * result + (hgvsTOrientation != null ? hgvsTOrientation.hashCode() : 0);
+        result = 31 * result + (genotypeList != null ? genotypeList.hashCode() : 0);
         result = 31 * result + (batch != null ? batch.hashCode() : 0);
         return result;
     }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
@@ -71,7 +71,7 @@ public class SubSnpCoreFields {
 
     private Orientation hgvsTOrientation;
 
-    private List<Map<String, String>> genotypeList;
+    private List<Map<String, String>> genotypes;
 
     /**
      * @param subSnpId          Unique SS ID identifier
@@ -138,11 +138,11 @@ public class SubSnpCoreFields {
         this.hgvsTStart = hgvsTStart;
         this.hgvsTStop = hgvsTStop;
         this.hgvsTOrientation = hgvsTOrientation;
-        this.genotypeList = getGenotypeListFromString(genotypes);
+        this.genotypes = getGenotypesFromString(genotypes);
         this.batch = batch;
     }
 
-    private List<Map<String, String>> getGenotypeListFromString (String genotypes_string) {
+    private List<Map<String, String>> getGenotypesFromString(String genotypes_string) {
         if (genotypes_string != null && !genotypes_string.isEmpty()) {
             boolean alleleOrientation = getAlleleOrientation();
             String ref = getReferenceInForwardStrand();
@@ -162,7 +162,7 @@ public class SubSnpCoreFields {
 
         return Arrays.stream(genotypePattern.split(genotypeString, -1))
                 .map(String::trim)
-                .map(alleles -> getForwardOrientedAllele(forward, alleles))
+                .map(allele -> getForwardOrientedAllele(forward, allele))
                 .collect(Collectors.joining(outputDelimiterToUse));
     }
 
@@ -270,12 +270,12 @@ public class SubSnpCoreFields {
         return hgvsTOrientation;
     }
 
-    public List<Map<String, String>> getGenotypeList() {
-        return genotypeList;
+    public List<Map<String, String>> getGenotypes() {
+        return genotypes;
     }
 
-    public void setGenotypeList(String genotypeList) {
-        this.genotypeList = getGenotypeListFromString(genotypeList);
+    public void setGenotypes(String genotypeString) {
+        this.genotypes = getGenotypesFromString(genotypeString);
     }
 
     public String getBatch() {
@@ -348,10 +348,14 @@ public class SubSnpCoreFields {
      * - rs10721689 :  "alleles" are reverse when orientations are 1 -1 1, forward when 1 -1 -1
      */
     public String getAllelesInForwardStrand() {
-        return getForwardOrientedAllele(getAlleleOrientation(), this.getAlleles());
+        return getForwardOrientedAlleles(getAlleleOrientation(), this.getAlleles());
     }
 
     private String getForwardOrientedAllele(boolean forward, String alleles) {
+        return getTrimmedAllele(forward ? alleles : calculateReverseComplement(alleles));
+    }
+
+    private String getForwardOrientedAlleles(boolean forward, String alleles) {
         String forwardAlleles = forward ? alleles : calculateReverseComplement(alleles);
         String[] splitAlleles = forwardAlleles.split("/", -1);
         return Stream.of(splitAlleles).map(this::getTrimmedAllele).collect(Collectors.joining("/"));
@@ -483,7 +487,7 @@ public class SubSnpCoreFields {
         if (hgvsTStart != null ? !hgvsTStart.equals(that.hgvsTStart) : that.hgvsTStart != null) return false;
         if (hgvsTStop != null ? !hgvsTStop.equals(that.hgvsTStop) : that.hgvsTStop != null) return false;
         if (hgvsTOrientation != that.hgvsTOrientation) return false;
-        if (!genotypeList.equals(that.genotypeList)) return false;
+        if (!genotypes.equals(that.genotypes)) return false;
         return batch != null ? batch.equals(that.batch) : that.batch == null;
     }
 
@@ -509,7 +513,7 @@ public class SubSnpCoreFields {
         result = 31 * result + (hgvsTStart != null ? hgvsTStart.hashCode() : 0);
         result = 31 * result + (hgvsTStop != null ? hgvsTStop.hashCode() : 0);
         result = 31 * result + (hgvsTOrientation != null ? hgvsTOrientation.hashCode() : 0);
-        result = 31 * result + (genotypeList != null ? genotypeList.hashCode() : 0);
+        result = 31 * result + (genotypes != null ? genotypes.hashCode() : 0);
         result = 31 * result + (batch != null ? batch.hashCode() : 0);
         return result;
     }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFields.java
@@ -351,8 +351,8 @@ public class SubSnpCoreFields {
         return getForwardOrientedAlleles(getAlleleOrientation(), this.getAlleles());
     }
 
-    private String getForwardOrientedAllele(boolean forward, String alleles) {
-        return getTrimmedAllele(forward ? alleles : calculateReverseComplement(alleles));
+    private String getForwardOrientedAllele(boolean forward, String allele) {
+        return getTrimmedAllele(forward ? allele : calculateReverseComplement(allele));
     }
 
     private String getForwardOrientedAlleles(boolean forward, String alleles) {

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SubSnpCoreFieldsReaderTest.java
@@ -106,6 +106,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                        "T", "T", "A", "T/A",
                                                        "NC_006091.4:g.91223961T>A", 91223961L, 91223961L, Orientation.FORWARD,
                                                        "NT_455866.1:g.1766472T>A", 1766472L, 1766472L, Orientation.FORWARD,
+                                                       null,
                                                        BATCH_NAME_2));
         expectedSubsnpsBatch2.add(new SubSnpCoreFields(26201546, Orientation.FORWARD,
                                                        13677177L, Orientation.FORWARD,
@@ -120,6 +121,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                        "T", "T", "C", "T/A",
                                                        "NC_006091.4:g.91223961T>C", 91223961L, 91223961L, Orientation.FORWARD,
                                                        "NT_455866.1:g.1766472T>C", 1766472L, 1766472L, Orientation.FORWARD,
+                                                       null,
                                                        BATCH_NAME_2));
 
 
@@ -137,6 +139,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                        "T", "T", "A", "G/A",
                                                        "NC_006091.4:g.91223961T>A", 91223961L, 91223961L, Orientation.FORWARD,
                                                        "NT_455866.1:g.1766472T>A", 1766472L, 1766472L, Orientation.FORWARD,
+                                                       "A/A,G/G",
                                                        BATCH_NAME_3));
         expectedSubsnpsBatch3.add(new SubSnpCoreFields(26954817, Orientation.REVERSE,
                                                        13677177L, Orientation.FORWARD,
@@ -151,6 +154,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                        "T", "T", "C", "G/A",
                                                        "NC_006091.4:g.91223961T>C", 91223961L, 91223961L, Orientation.FORWARD,
                                                        "NT_455866.1:g.1766472T>C", 1766472L, 1766472L, Orientation.FORWARD,
+                                                        "A/A,G/G",
                                                        BATCH_NAME_3));
         expectedSubsnpsBatch3.add(new SubSnpCoreFields(26963037, Orientation.FORWARD,
                                                        13677177L, Orientation.FORWARD,
@@ -165,6 +169,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                        "T", "T", "A", "T/A",
                                                        "NC_006091.4:g.91223961T>A", 91223961L, 91223961L, Orientation.FORWARD,
                                                        "NT_455866.1:g.1766472T>A", 1766472L, 1766472L, Orientation.FORWARD,
+                                                       "A/A,T/T",
                                                        BATCH_NAME_3));
         expectedSubsnpsBatch3.add(new SubSnpCoreFields(26963037, Orientation.FORWARD,
                                                        13677177L, Orientation.FORWARD,
@@ -179,6 +184,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                        "T", "T", "C", "T/A",
                                                        "NC_006091.4:g.91223961T>C", 91223961L, 91223961L, Orientation.FORWARD,
                                                        "NT_455866.1:g.1766472T>C", 1766472L, 1766472L, Orientation.FORWARD,
+                                                       "A/A,T/T",
                                                        BATCH_NAME_3));
     }
 
@@ -262,6 +268,7 @@ public class SubSnpCoreFieldsReaderTest extends ReaderTest {
                                                          47119827L, 47119830L, Orientation.FORWARD,
                                                          "NT_455837.1:g.11724980_11724983delCCGA",
                                                          11724980L, 11724983L, Orientation.REVERSE,
+                                                         null,
                                                          "CHICKEN_INDEL_DWBURT"));
         int fakeBatch = 1;
         reader = buildReader(fakeBatch, CHICKEN_ASSEMBLY_4, 100);

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MatchingAllelesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MatchingAllelesFilterProcessorTest.java
@@ -33,27 +33,27 @@ public class MatchingAllelesFilterProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "T", "T", "A", "T/A", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, "batch"));
+                                     1766472L, Orientation.FORWARD, null, "batch"));
         matchingAllelesVariants.add(
                 new SubSnpCoreFields(26954817L, Orientation.REVERSE, 13677177L, Orientation.FORWARD, "NT_455866.1",
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "T", "T", "C", "G/A", "NC_006091.4:g.91223961T>C", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>C", 1766472L,
-                                     1766472L, Orientation.FORWARD, "batch"));
+                                     1766472L, Orientation.FORWARD, null, "batch"));
         matchingAllelesVariants.add(
                 new SubSnpCoreFields(26963037L, Orientation.FORWARD, 13677177L, Orientation.FORWARD, "NT_455866.1",
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "T", "T", "A", "T/A", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, "batch"));
+                                     1766472L, Orientation.FORWARD, null, "batch"));
         matchingAllelesVariants.add(
                 new SubSnpCoreFields(0, Orientation.REVERSE, 0L, Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD,
                                      LocusType.SNP, "4", 0L, 0L, "T", "T", "C", "T/A/G", "", 0L, 0L,
-                                     Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD, "batch"));
+                                     Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD, null, "batch"));
         matchingAllelesVariants.add(
                 new SubSnpCoreFields(0, Orientation.REVERSE, 0L, Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD,
                                      LocusType.SNP, "4", 0L, 0L, "AT", "AT", "TGG", "TT/AT/CCA", "", 0L, 0L,
-                                     Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD, "batch"));
+                                     Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD, null, "batch"));
 
         mismatchingAllelesVariants = new ArrayList<>();
         mismatchingAllelesVariants.add(
@@ -61,23 +61,23 @@ public class MatchingAllelesFilterProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L, 91223961L,
                                      "T", "T", "C", "T/A", "NC_006091.4:g.91223961T>C", 91223961L, 91223961L,
                                      Orientation.FORWARD, "NT_455866.1:g.1766472T>C", 1766472L, 1766472L,
-                                     Orientation.FORWARD, "batch"));
+                                     Orientation.FORWARD, null, "batch"));
         mismatchingAllelesVariants.add(
                 new SubSnpCoreFields(26954817, Orientation.REVERSE, 13677177L, Orientation.FORWARD, "NT_455866.1",
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L, 91223961L,
                                      "T", "T", "A", "G/A", "NC_006091.4:g.91223961T>A", 91223961L, 91223961L,
                                      Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L, 1766472L,
-                                     Orientation.FORWARD, "batch"));
+                                     Orientation.FORWARD, null, "batch"));
         mismatchingAllelesVariants.add(
                 new SubSnpCoreFields(26963037, Orientation.FORWARD, 13677177L, Orientation.FORWARD, "NT_455866.1",
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L, 91223961L,
                                      "T", "T", "C", "T/A", "NC_006091.4:g.91223961T>C", 91223961L, 91223961L,
                                      Orientation.FORWARD, "NT_455866.1:g.1766472T>C", 1766472L, 1766472L,
-                                     Orientation.FORWARD, "batch"));
+                                     Orientation.FORWARD, null, "batch"));
         mismatchingAllelesVariants.add(
                 new SubSnpCoreFields(0, Orientation.FORWARD, 0L, Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD,
                                      LocusType.SNP, "4", 0L, 0L, "T", "T", "C", "T/A/G", "", 0L, 0L,
-                                     Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD, "batch"));
+                                     Orientation.FORWARD, "", 0L, 0L, Orientation.FORWARD, null, "batch"));
     }
 
     @Test

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/MissingCoordinatesFilterProcessorTest.java
@@ -40,7 +40,7 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                  LocusType.SNP, "4", 1L, 1L, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
         assertNotNull(filter.process(subSnpCoreFields));
     }
 
@@ -50,7 +50,7 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                   "NT_455866.1", null, null, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "T", "T", "A", "T/A", "",
                                                                   null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
         assertNotNull(filter.process(subSnpCoreFields));
     }
 
@@ -60,7 +60,7 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                  "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                  LocusType.SNP, "4", null, null, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
         assertNotNull(filter.process(subSnpCoreFields));
     }
 
@@ -70,7 +70,7 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                  "NT_455866.1", null, 1L, Orientation.FORWARD,
                                                                  LocusType.SNP, "4", null, 1L, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
         assertNull(filter.process(subSnpCoreFields));
     }
 
@@ -80,7 +80,7 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                  "NT_455866.1", 1L, null, Orientation.FORWARD,
                                                                  LocusType.SNP, "4", 1L, null, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
         assertNull(filter.process(subSnpCoreFields));
     }
 
@@ -90,7 +90,7 @@ public class MissingCoordinatesFilterProcessorTest {
                                                                  "NT_455866.1", null, null, Orientation.FORWARD,
                                                                  LocusType.SNP, "4", null, null, "T", "T", "A", "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
         assertNull(filter.process(subSnpCoreFields));
     }
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/RefseqToGenbankMappingProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/RefseqToGenbankMappingProcessorTest.java
@@ -53,7 +53,7 @@ public class RefseqToGenbankMappingProcessorTest {
                                                                  LocusType.SNP, "4", null, null, "T", "T", "A", "T/A",
                                                                  "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields processed = refseqToGenbankMappingProcessor.process(subSnpCoreFields);
 
@@ -68,7 +68,7 @@ public class RefseqToGenbankMappingProcessorTest {
                                                                  LocusType.SNP, CHROMOSOME, 1L, 1L, "T", "T", "A",
                                                                  "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields processed = refseqToGenbankMappingProcessor.process(subSnpCoreFields);
 
@@ -84,7 +84,7 @@ public class RefseqToGenbankMappingProcessorTest {
                                                                  LocusType.SNP, CHROMOSOME, null, null, "T", "T", "A",
                                                                  "T/A", "",
                                                                  null, null, Orientation.FORWARD, null, null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields processed = refseqToGenbankMappingProcessor.process(subSnpCoreFields);
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest.java
@@ -49,7 +49,7 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "T", "T", "A", "T/A", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "T", "A");
         variant.setMainId("rs" + 13677177L);
         Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
@@ -65,7 +65,7 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "A", "A", "G", "T/C", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "G");
         variant.setMainId("rs" + 13677177L);
         Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
@@ -81,7 +81,7 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.INSERTION, "4", 91223960L,
                                      91223961L, "-", "-", "A", "-/A", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "", "A");
         variant.setMainId("rs" + 13677177L);
         Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
@@ -97,7 +97,7 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.DELETION, "4", 91223961L,
                                      91223961L, "A", "A", "-", "A/-", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "");
         variant.setMainId("rs" + 13677177L);
         Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);
@@ -113,7 +113,7 @@ public class SubSnpCoreFieldsToEvaSubmittedVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.LONGER_ON_CONTIG, "4", 91223961L,
                                      91223961L, "GTA", "GTA", "T", "TAC/A/CC", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223963L, "GTA", "T");
         variant.setMainId("rs" + 13677177L);
         Set<String> ids = TestUtils.buildIds(26201546L, 13677177L);

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/SubSnpCoreFieldsToVariantProcessorTest.java
@@ -25,9 +25,12 @@ import uk.ac.ebi.eva.commons.core.models.pipeline.VariantSourceEntry;
 import uk.ac.ebi.eva.dbsnpimporter.models.LocusType;
 import uk.ac.ebi.eva.dbsnpimporter.models.Orientation;
 import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFields;
+import uk.ac.ebi.eva.dbsnpimporter.models.SubSnpCoreFieldsTest;
 import uk.ac.ebi.eva.dbsnpimporter.test.TestUtils;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -54,7 +57,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "T", "T", "A", "T/A", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "T", "A");
         variant.setMainId("rs" + 13677177L);
         variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
@@ -62,6 +65,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[0], null, null,
                                                                 attributes, null);
+
         variant.addSourceEntry(sourceEntry);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
@@ -74,7 +78,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.SNP, "4", 91223961L,
                                      91223961L, "A", "A", "G", "T/C", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "G");
         variant.setMainId("rs" + 13677177L);
         variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
@@ -94,7 +98,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.INSERTION, "4", 91223960L,
                                      91223961L, "-", "-", "A", "-/A", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "", "A");
         variant.setMainId("rs" + 13677177L);
         variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
@@ -114,7 +118,7 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.DELETION, "4", 91223961L,
                                      91223961L, "A", "A", "-", "A/-", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, null, DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223961L, "A", "");
         variant.setMainId("rs" + 13677177L);
         variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
@@ -134,14 +138,18 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
                                      1766472L, 1766472L, Orientation.FORWARD, LocusType.LONGER_ON_CONTIG, "4", 91223961L,
                                      91223961L, "GTA", "GTA", "T", "TAC/A/CC", "NC_006091.4:g.91223961T>A", 91223961L,
                                      91223961L, Orientation.FORWARD, "NT_455866.1:g.1766472T>A", 1766472L,
-                                     1766472L, Orientation.FORWARD, DBSNP_BATCH);
+                                     1766472L, Orientation.FORWARD, "TAC|A, A|CC", DBSNP_BATCH);
         Variant variant = new Variant("4", 91223961L, 91223963L, "GTA", "T");
         variant.setMainId("rs" + 13677177L);
         variant.setDbsnpIds(TestUtils.buildIds(26201546L, 13677177L));
         Map<String, String> attributes = Collections.singletonMap(DBSNP_BUILD_KEY, String.valueOf(DBSNP_BUILD));
+
+        List<Map<String, String>> genotypeMap = new ArrayList<>();
+        genotypeMap.add(SubSnpCoreFieldsTest.createGenotypeMap("GT", "0|1"));
+        genotypeMap.add(SubSnpCoreFieldsTest.createGenotypeMap("GT", "1|2"));
         VariantSourceEntry sourceEntry = new VariantSourceEntry(String.valueOf(DBSNP_BATCH),
                                                                 String.valueOf(DBSNP_BATCH), new String[]{"GG"}, null,
-                                                                null, attributes, null);
+                                                                null, attributes, genotypeMap);
         variant.addSourceEntry(sourceEntry);
 
         assertVariantEquals(variant, processor.process(subSnpCoreFields));
@@ -161,5 +169,6 @@ public class SubSnpCoreFieldsToVariantProcessorTest {
         assertEquals(sourceEntry.getStudyId(), actualSourceEntry.getStudyId());
         assertArrayEquals(sourceEntry.getSecondaryAlternates(), actualSourceEntry.getSecondaryAlternates());
         assertEquals(sourceEntry.getAttributes(), actualSourceEntry.getAttributes());
+        assertEquals(sourceEntry.getSamplesData(), actualSourceEntry.getSamplesData());
     }
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessorTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/jobs/steps/processors/UnambiguousAllelesFilterProcessorTest.java
@@ -34,26 +34,26 @@ public class UnambiguousAllelesFilterProcessorTest {
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "T", "T", "A", "T/A", "",
                                                                   null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "TAGC", "TAGC", "A",
                                                                   "TAGC/A", "", null, null, Orientation.FORWARD, null,
-                                                                  null, null, Orientation.FORWARD, "batch");
+                                                                  null, null, Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "aCgTAcGt", "aCgTAcGt",
                                                                   "AAACCTg", "aCgTAcGt/AAACCTg", "", null, null,
                                                                   Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "", "", "ACgt", "/ACgt",
                                                                   "", null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertNotNull(filter.process(subSnpCoreFields1));
         assertNotNull(filter.process(subSnpCoreFields2));
@@ -67,26 +67,26 @@ public class UnambiguousAllelesFilterProcessorTest {
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "N", "N", "A", "N/A", "",
                                                                   null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "AGYT", "AGYT", "A",
                                                                   "AGYT/A", "", null, null, Orientation.FORWARD, null,
-                                                                  null, null, Orientation.FORWARD, "batch");
+                                                                  null, null, Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "rxyz", "rxyz",
                                                                   "AAACCTg", "rxyz/AAACCTg", "", null, null,
                                                                   Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "y", "y", "ACg", "y/ACg",
                                                                   "", null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertNull(filter.process(subSnpCoreFields1));
         assertNull(filter.process(subSnpCoreFields2));
@@ -100,26 +100,26 @@ public class UnambiguousAllelesFilterProcessorTest {
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "A", "A", "N", "A/N", "",
                                                                   null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "A", "A", "AGYT",
                                                                   "A/AGYT", "", null, null, Orientation.FORWARD, null,
-                                                                  null, null, Orientation.FORWARD, "batch");
+                                                                  null, null, Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields3 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "AAACCTg", "AAACCTg",
                                                                   "rxyz", "AAACCTg/rxyz", "", null, null,
                                                                   Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         SubSnpCoreFields subSnpCoreFields4 = new SubSnpCoreFields(1L, Orientation.FORWARD, 1L, Orientation.FORWARD,
                                                                   "NT_455866.1", 1L, 1L, Orientation.FORWARD,
                                                                   LocusType.SNP, "4", 1L, 1L, "Ag", "Ag", "y", "y/Ag",
                                                                   "", null, null, Orientation.FORWARD, null, null, null,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertNull(filter.process(subSnpCoreFields1));
         assertNull(filter.process(subSnpCoreFields2));

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsForwardStrandMappingTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsForwardStrandMappingTest.java
@@ -394,6 +394,9 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
         assertEquals("/T/",
                      buildSubSnpCoreFieldsWithOrientations("/A/", Orientation.REVERSE, Orientation.FORWARD,
                                                            Orientation.FORWARD).getAllelesInForwardStrand());
+        assertEquals("T///",
+                     buildSubSnpCoreFieldsWithOrientations("/- /-/A", Orientation.REVERSE, Orientation.FORWARD,
+                                                           Orientation.FORWARD).getAllelesInForwardStrand());
     }
 
     @Test

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsForwardStrandMappingTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsForwardStrandMappingTest.java
@@ -44,7 +44,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223961T>A", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766472T>A", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("T", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("A", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -69,7 +69,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223962insAGA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473insAGA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("T", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("TAGA", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -90,7 +90,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223962insA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473insA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("", subSnpCoreFields2.getReferenceInForwardStrand());
         assertEquals("TA", subSnpCoreFields2.getAlternateInForwardStrand());
@@ -111,7 +111,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223962insA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473insA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("", subSnpCoreFields3.getReferenceInForwardStrand());
         assertEquals("TA", subSnpCoreFields3.getAlternateInForwardStrand());
@@ -135,7 +135,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223962delAGA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.17664723delAGA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("TAGA", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("T", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -156,7 +156,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223961delTA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766472delTA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("TA", subSnpCoreFields2.getReferenceInForwardStrand());
         assertEquals("", subSnpCoreFields2.getAlternateInForwardStrand());
@@ -177,7 +177,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223961delTA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766472delTA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("TA", subSnpCoreFields3.getReferenceInForwardStrand());
         assertEquals("", subSnpCoreFields3.getAlternateInForwardStrand());
@@ -200,7 +200,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   null, "T", "A", "T/A",
                                                                   null, null, null, Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766472T>A", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("T", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("A", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -220,7 +220,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "-", "-", "TA", "-/TA",
                                                                   null, null, null, Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473insA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("", subSnpCoreFields2.getReferenceInForwardStrand());
         assertEquals("TA", subSnpCoreFields2.getAlternateInForwardStrand());
@@ -240,7 +240,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "TAGA", "TAGA", "T", "TAGA/T",
                                                                   null, null, null, Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473delAGA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("TAGA", subSnpCoreFields3.getReferenceInForwardStrand());
         assertEquals("T", subSnpCoreFields3.getAlternateInForwardStrand());
@@ -263,7 +263,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223962insAGA", 91223961L, 91223961L,
                                                                   Orientation.REVERSE,
                                                                   "NT_455866.1:g.1766473insAGA", 1766472L, 1766472L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("A", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("TCTA", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -284,7 +284,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006112.3:g.88998_88999insC", 88997L, 88998L,
                                                                   Orientation.REVERSE,
                                                                   "NT_456010.1:g.107453_107454insG", 107452L, 107453L,
-                                                                  Orientation.FORWARD, "batch");
+                                                                  Orientation.FORWARD, null, "batch");
 
         assertEquals("", subSnpCoreFields2.getReferenceInForwardStrand());
         assertEquals("C", subSnpCoreFields2.getAlternateInForwardStrand());
@@ -307,7 +307,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "NC_006091.4:g.91223962insAGA", 91223961L, 91223961L,
                                                                   Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473insAGA", 1766472L, 1766472L,
-                                                                  Orientation.REVERSE, "batch");
+                                                                  Orientation.REVERSE, null, "batch");
 
         assertEquals("T", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("TAGA", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -329,7 +329,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                                                   "T", "T", "TAGA", "T/TAGA",
                                                                   null, null, null, Orientation.FORWARD,
                                                                   "NT_455866.1:g.1766473insAGA", 1766472L, 1766472L,
-                                                                  Orientation.REVERSE, "batch");
+                                                                  Orientation.REVERSE, null, "batch");
 
         assertEquals("A", subSnpCoreFields1.getReferenceInForwardStrand());
         assertEquals("TCTA", subSnpCoreFields1.getAlternateInForwardStrand());
@@ -367,7 +367,7 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                     LocusType.SNP, "", 0L, 0L,
                                     "", "", "", alleles,
                                     "", 0L, 0L, Orientation.FORWARD,
-                                    "", 0L, 0L, Orientation.FORWARD, "batch");
+                                    "", 0L, 0L, Orientation.FORWARD, null, "batch");
     }
 
     @Test
@@ -443,6 +443,6 @@ public class SubSnpCoreFieldsForwardStrandMappingTest {
                                     LocusType.SNP, "", 0L, 0L,
                                     reference, reference, alternate, alleles,
                                     "", 0L, 0L, Orientation.FORWARD,
-                                    "", 0L, 0L, Orientation.FORWARD, "batch");
+                                    "", 0L, 0L, Orientation.FORWARD, null, "batch");
     }
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
@@ -29,7 +29,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                     "NW_003104285.1", 12108029L, 12108029L, Orientation.FORWARD,
                                                     LocusType.SNP, "10", 100002924L, 100002924L, null, null, null, null,
                                                     null, null, null, Orientation.REVERSE, null, null, null,
-                                                    Orientation.REVERSE, "batch");
+                                                    Orientation.REVERSE, null, "batch");
 
         assertEquals(new Region("10", 100002924L, 100002924L), snp.getVariantCoordinates());
     }
@@ -39,7 +39,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
         SubSnpCoreFields snp = new SubSnpCoreFields(1107437104L, Orientation.FORWARD, 524908995L, Orientation.FORWARD,
                                                     "NW_003101163.1", 943L, 943L, Orientation.FORWARD, LocusType.SNP,
                                                     null, null, null, null, null, null, null, null, null, null,
-                                                    Orientation.REVERSE, null, null, null, Orientation.REVERSE, "batch");
+                                                    Orientation.REVERSE, null, null, null, Orientation.REVERSE, null, "batch");
 
         assertEquals(new Region("NW_003101163.1", 943L, 943L), snp.getVariantCoordinates());
     }
@@ -51,7 +51,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                          Orientation.FORWARD, LocusType.DELETION, "12", 10144047L,
                                                          10144047L, null, null, null, null, null, null, null,
                                                          Orientation.REVERSE, null, null, null, Orientation.REVERSE,
-                                                         "batch");
+                null, "batch");
 
         assertEquals(new Region("12", 10144047L, 10144047L), deletion.getVariantCoordinates());
     }
@@ -63,7 +63,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                          Orientation.FORWARD, LocusType.DELETION, "2", 100306584L,
                                                          100306586L, null, null, null, null, null, null, null,
                                                          Orientation.REVERSE, null, null, null, Orientation.REVERSE,
-                                                         "batch");
+                null, "batch");
 
         assertEquals(new Region("2", 100306584L, 100306586L), deletion.getVariantCoordinates());
     }
@@ -74,7 +74,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                          Orientation.FORWARD, "NW_003101162.1", 229L, 232L,
                                                          Orientation.FORWARD, LocusType.DELETION, null, null, null,
                                                          null, null, null, null, null, null, null, Orientation.REVERSE,
-                                                         null, null, null, Orientation.REVERSE, "batch");
+                                                         null, null, null, Orientation.REVERSE, null, "batch");
 
         assertEquals(new Region("NW_003101162.1", 229L, 232L), deletion.getVariantCoordinates());
     }
@@ -88,7 +88,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                           "AC_000167.1:g.100013652_100013653insA", 100013652L,
                                                           100013653L, Orientation.FORWARD,
                                                           "NW_003104285.1:g.12118757_12118758insA", 12118757L,
-                                                          12118758L, Orientation.FORWARD, "batch");
+                                                          12118758L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new Region("10", 100013653L, 100013653L), insertion.getVariantCoordinates());
 
@@ -103,7 +103,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                           "AC_000162.1:g.100080173_100080174insTTGCA", 100080173L,
                                                           100080174L, Orientation.FORWARD,
                                                           "NW_003103939.1:g.12276_12277insTTGCA", 12276L, 12277L,
-                                                          Orientation.FORWARD, "batch");
+                                                          Orientation.FORWARD, null, "batch");
 
         assertEquals(new Region("5", 100080174L, 100080178L), insertion.getVariantCoordinates());
     }
@@ -115,7 +115,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                           Orientation.FORWARD, LocusType.INSERTION, null, null, null,
                                                           null, "-", "AA", "-/AA", null, null, null,
                                                           Orientation.FORWARD, "NW_003101162.1:g.189_190insAA", 189L,
-                                                          190L, Orientation.FORWARD, "batch");
+                                                          190L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new Region("NW_003101162.1", 190L, 191L), insertion.getVariantCoordinates());
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
@@ -51,7 +51,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                          Orientation.FORWARD, LocusType.DELETION, "12", 10144047L,
                                                          10144047L, null, null, null, null, null, null, null,
                                                          Orientation.REVERSE, null, null, null, Orientation.REVERSE,
-                                                        null, "batch");
+                                                         null, "batch");
 
         assertEquals(new Region("12", 10144047L, 10144047L), deletion.getVariantCoordinates());
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
@@ -63,7 +63,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                          Orientation.FORWARD, LocusType.DELETION, "2", 100306584L,
                                                          100306586L, null, null, null, null, null, null, null,
                                                          Orientation.REVERSE, null, null, null, Orientation.REVERSE,
-                null, "batch");
+                                                         null, "batch");
 
         assertEquals(new Region("2", 100306584L, 100306586L), deletion.getVariantCoordinates());
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoordinatesTest.java
@@ -51,7 +51,7 @@ public class SubSnpCoreFieldsGetVariantCoordinatesTest {
                                                          Orientation.FORWARD, LocusType.DELETION, "12", 10144047L,
                                                          10144047L, null, null, null, null, null, null, null,
                                                          Orientation.REVERSE, null, null, null, Orientation.REVERSE,
-                null, "batch");
+                                                        null, "batch");
 
         assertEquals(new Region("12", 10144047L, 10144047L), deletion.getVariantCoordinates());
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoreFieldsTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsGetVariantCoreFieldsTest.java
@@ -31,7 +31,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                     LocusType.SNP, "10", 100002924L, 100002924L, "C", "C", "T", null,
                                                     "AC_000167.1:g.100002924C>T", 100002924L, 100002924L,
                                                     Orientation.FORWARD, "NW_003104285.1:g.12108029C>T", 12108029L,
-                                                    12108029L, Orientation.FORWARD, "batch");
+                                                    12108029L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("10", 100002924L, "C", "T"), snp.getVariantCoreFields());
     }
@@ -42,7 +42,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                     "NW_003101163.1", 943L, 943L, Orientation.FORWARD, LocusType.SNP,
                                                     null, null, null, null, "C", "A", null, null, null, null,
                                                     Orientation.FORWARD, "NW_003101163.1:g.943C>A", 943L, 943L,
-                                                    Orientation.FORWARD, "batch");
+                                                    Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("NW_003101163.1", 943L, "C", "A"), snp.getVariantCoreFields());
     }
@@ -54,7 +54,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                          Orientation.FORWARD, LocusType.SNP, "12", 10144047L, 10144047L,
                                                          "G", "G", null, null, "AC_000169.1:g.10144047delG", 10144047L,
                                                          10144047L, Orientation.FORWARD, "AC_000169.1:g.10144047delG",
-                                                         1591551L, 1591551L, Orientation.FORWARD, "batch");
+                                                         1591551L, 1591551L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("12", 10144047L, "G", ""), deletion.getVariantCoreFields());
     }
@@ -68,7 +68,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                          "AC_000159.1:g.100306584_100306586delTCA", 100306584L,
                                                          100306586L, Orientation.FORWARD,
                                                          "NW_003103847.1:g.1056819_1056821delTCA", 1056819L, 1056821L,
-                                                         Orientation.REVERSE, "batch");
+                                                         Orientation.REVERSE, null, "batch");
 
         assertEquals(new VariantCoreFields("2", 100306584L, "TCA", ""), deletion.getVariantCoreFields());
     }
@@ -80,7 +80,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                          Orientation.FORWARD, LocusType.DELETION, null, null, null,
                                                          null, "TTTC", null, null, null, null, null,
                                                          Orientation.FORWARD, "NW_003101162.1:g.229_232delTTTC", 229L,
-                                                         232L, Orientation.FORWARD, "batch");
+                                                         232L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("NW_003101162.1", 229L, "TTTC", ""), deletion.getVariantCoreFields());
     }
@@ -94,7 +94,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                           "AC_000167.1:g.100013652_100013653insA", 100013652L,
                                                           100013653L, Orientation.FORWARD,
                                                           "NW_003104285.1:g.12118757_12118758insA", 12118757L,
-                                                          12118758L, Orientation.FORWARD, "batch");
+                                                          12118758L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("10", 100013653L, "", "A"), insertion.getVariantCoreFields());
 
@@ -109,7 +109,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                           "AC_000162.1:g.100080173_100080174insTTGCA", 100080173L,
                                                           100080174L, Orientation.FORWARD,
                                                           "NW_003103939.1:g.12276_12277insTTGCA", 12276L, 12277L,
-                                                          Orientation.FORWARD, "batch");
+                                                          Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("5", 100080174L, "", "TTGCA"), insertion.getVariantCoreFields());
     }
@@ -121,7 +121,7 @@ public class SubSnpCoreFieldsGetVariantCoreFieldsTest {
                                                           Orientation.FORWARD, LocusType.INSERTION, null, null, null,
                                                           null, "-", "AA", "-/AA", null, null, null,
                                                           Orientation.FORWARD, "NW_003101162.1:g.189_190insAA", 189L,
-                                                          190L, Orientation.FORWARD, "batch");
+                                                          190L, Orientation.FORWARD, null, "batch");
 
         assertEquals(new VariantCoreFields("NW_003101162.1", 190L, "", "AA"), insertion.getVariantCoreFields());
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
@@ -19,6 +19,11 @@ import org.junit.Test;
 
 import uk.ac.ebi.eva.commons.core.models.Region;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -31,7 +36,7 @@ public class SubSnpCoreFieldsTest {
                                                                  "contigName", 1L, 10L, Orientation.REVERSE,
                                                                  LocusType.SNP, "chromosomeName", 5L, 50L, "A", "A",
                                                                  "T", "T/A", "", null, null, Orientation.FORWARD, "",
-                                                                 null, null, Orientation.FORWARD, "batch");
+                                                                 null, null, Orientation.FORWARD, null, "batch");
 
         assertEquals(12345, subSnpCoreFields.getSsId());
         assertNotNull(subSnpCoreFields.getRsId());
@@ -48,7 +53,7 @@ public class SubSnpCoreFieldsTest {
                                                                  "contigName", 1L, 10L, Orientation.REVERSE,
                                                                  LocusType.SNP, null, null, null, "T", "T", "A", "T/A",
                                                                  "", null, null, Orientation.FORWARD, "", null, null,
-                                                                 Orientation.FORWARD, "batch");
+                                                                 Orientation.FORWARD, null, "batch");
 
         assertEquals(12345, subSnpCoreFields.getSsId());
         assertEquals(Orientation.FORWARD, subSnpCoreFields.getSnpOrientation());
@@ -63,7 +68,7 @@ public class SubSnpCoreFieldsTest {
                                                                  "contigName", 1L, 10L, Orientation.REVERSE,
                                                                  LocusType.SNP, "chromosomeName", null, null, "T", "T",
                                                                  "A", "T/A", "", null, null, Orientation.FORWARD, "",
-                                                                 null, null, Orientation.FORWARD, "batch");
+                                                                 null, null, Orientation.FORWARD, null, "batch");
 
         assertEquals(12345, subSnpCoreFields.getSsId());
         assertEquals(Orientation.FORWARD, subSnpCoreFields.getSnpOrientation());
@@ -78,7 +83,7 @@ public class SubSnpCoreFieldsTest {
                                                                  "contigName", null, null, Orientation.REVERSE,
                                                                  LocusType.SNP, "chromosomeName", 1L, 10L,"T", "T",
                                                                  "A", "T/A", "", null, null, Orientation.FORWARD, "",
-                                                                 null, null, Orientation.FORWARD, "batch");
+                                                                 null, null, Orientation.FORWARD, null, "batch");
 
         assertEquals(12345, subSnpCoreFields.getSsId());
         assertEquals(Orientation.FORWARD, subSnpCoreFields.getSnpOrientation());
@@ -93,12 +98,12 @@ public class SubSnpCoreFieldsTest {
                                                                   "contigName", 1L, 10L, Orientation.REVERSE,
                                                                   LocusType.SNP, "chromosomeName", 5L, 50L, "T", "T",
                                                                   "A", "T/A", "", null, null, Orientation.FORWARD, "",
-                                                                  null, null, Orientation.FORWARD, "batch");
+                                                                  null, null, Orientation.FORWARD, null, "batch");
         SubSnpCoreFields subSnpCoreFields2 = new SubSnpCoreFields(2, Orientation.FORWARD, null, Orientation.FORWARD,
                                                                   "contigName", 1L, 10L, Orientation.REVERSE,
                                                                   LocusType.SNP, "chromosomeName", 5L, 50L, "T", "T",
                                                                   "A", "T/A", "", null, null, Orientation.FORWARD, "",
-                                                                  null, null, Orientation.FORWARD, "batch");
+                                                                  null, null, Orientation.FORWARD, null, "batch");
 
         assertEquals(1, subSnpCoreFields1.getSsId());
         assertNotNull(subSnpCoreFields1.getRsId());
@@ -112,7 +117,7 @@ public class SubSnpCoreFieldsTest {
     public void failWithNegativeContigCoordinates() {
         new SubSnpCoreFields(12345, Orientation.FORWARD, 123L, Orientation.FORWARD, "contigName", -1L, 10L,
                              Orientation.REVERSE, LocusType.SNP, "chromosomeName", null, null, "T", "T", "A", "T/A", "",
-                             null, null, Orientation.FORWARD, "", null, null, Orientation.FORWARD, "batch");
+                             null, null, Orientation.FORWARD, "", null, null, Orientation.FORWARD, null, "batch");
 
     }
 
@@ -121,7 +126,82 @@ public class SubSnpCoreFieldsTest {
     public void failWithNegativeChromosomeCoordinates() {
         new SubSnpCoreFields(12345, Orientation.FORWARD, 123L, Orientation.FORWARD, "contigName", 1L, 10L,
                              Orientation.REVERSE, LocusType.SNP, "chromosomeName", -5L, 50L, "T", "T", "A", "T/A", "",
-                             null, null, Orientation.FORWARD, "", null, null, Orientation.FORWARD, "batch");
+                             null, null, Orientation.FORWARD, "", null, null, Orientation.FORWARD, null, "batch");
+    }
+
+    @Test
+    public void testGenotypeList() {
+
+        //Test allele reverse orientation
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(3173433, Orientation.FORWARD, 2228714L, Orientation.REVERSE,
+                "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
+                LocusType.SNP, "3", 23412070L, 23412070L,"C", "C",
+                "T", "C/T", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.FORWARD, "NC_003074.8:g.23412070C>T",
+                23412070L, 23412070L, Orientation.FORWARD, "G/G,A/A, G/ A, A |G, ./.", "batch");
+        List<Map<String, String>> expectedGenotypeList = new ArrayList<>();
+        expectedGenotypeList.add(createGenotypeMap("GT", "0/0"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1/1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "0/1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1|0"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "./."));
+        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+
+        //Test allele forward orientation
+        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+                "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
+                LocusType.SNP, "3", 23412070L, 23412070L,"G", "G",
+                "A", "T/C", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.REVERSE, "NC_003074.8:g.23412070C>T",
+                23412070L, 23412070L, Orientation.REVERSE, "C/T, T/T, C/C, ./., T/C, C, T", "batch");
+        expectedGenotypeList = new ArrayList<>();
+        expectedGenotypeList.add(createGenotypeMap("GT", "0/1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1/1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "0/0"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "./."));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1/0"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "0"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1"));
+        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+
+        //Test hyphenated genotypes
+        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+                "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
+                LocusType.SNP, "3", 23412070L, 23412070L,"G", "G",
+                "", "C/-", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.REVERSE, "NC_003074.8:g.23412070C>T",
+                23412070L, 23412070L, Orientation.REVERSE, "-/ - ", "batch");
+        expectedGenotypeList = new ArrayList<>();
+        expectedGenotypeList.add(createGenotypeMap("GT", "1/1"));
+        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+
+        //Test multi-allelic genotypes - reverse orientation
+        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+                null, 23412070L, 23412073L, Orientation.REVERSE,
+                LocusType.SNP, "3", 23412070L, 23412073L,"TAC", "TAC",
+                "GGC", "GTA/GCC", "", 23412070L, 23412073L, Orientation.FORWARD, "",
+                23412070L, 23412073L, Orientation.FORWARD, "GTA |GCC, GCC|GCC, GTA|GTA", "batch");
+        expectedGenotypeList = new ArrayList<>();
+        expectedGenotypeList.add(createGenotypeMap("GT", "0|1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1|1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "0|0"));
+        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+
+        //Test multi-allelic genotypes - forward orientation
+        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+                null, 23412070L, 23412073L, Orientation.FORWARD,
+                LocusType.SNP, "3", 23412070L, 23412073L,"TAC", "TAC",
+                "GGC", "TAC/GGC/CCT", "", 23412070L, 23412073L, Orientation.FORWARD, "",
+                23412070L, 23412073L, Orientation.FORWARD, "TAC |GGC, GGC|GGC, TAC/TAC, CCT/GGC", "batch");
+        expectedGenotypeList = new ArrayList<>();
+        expectedGenotypeList.add(createGenotypeMap("GT", "0|1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "1|1"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "0/0"));
+        expectedGenotypeList.add(createGenotypeMap("GT", "2/1"));
+        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+    }
+
+    public static Map<String, String> createGenotypeMap (String key, String value) {
+        Map<String, String> genotypeMap = new HashMap<>();
+        genotypeMap.put(key, value);
+        return  genotypeMap;
     }
 
 }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
@@ -135,7 +135,7 @@ public class SubSnpCoreFieldsTest {
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(3173433, Orientation.FORWARD, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
                 LocusType.SNP, "3", 23412070L, 23412070L, "C", "C",
-                "T", "C/T", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.FORWARD, "NC_003074.8:g.23412070C>T",
+                "T", "G/A", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.FORWARD, "NC_003074.8:g.23412070C>T",
                 23412070L, 23412070L, Orientation.FORWARD, "G/G,A/A, G/ A, A |G, ./.", "batch");
         List<Map<String, String>> expectedGenotypes = new ArrayList<>();
         expectedGenotypes.add(createGenotypeMap("GT", "0/0"));
@@ -184,12 +184,13 @@ public class SubSnpCoreFieldsTest {
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 null, 23412070L, 23412073L, Orientation.REVERSE,
                 LocusType.SNP, "3", 23412070L, 23412073L, "TAC", "TAC",
-                "GGC", "GTA/GCC", "", 23412070L, 23412073L, Orientation.FORWARD, "",
-                23412070L, 23412073L, Orientation.FORWARD, "GTA |GCC, GCC|GCC, GTA|GTA", "batch");
+                "GGC", "GTA/GCC/GC", "", 23412070L, 23412073L, Orientation.FORWARD, "",
+                23412070L, 23412073L, Orientation.FORWARD, "GTA |GCC, GCC|GCC, GTA|GTA, GC/GC", "batch");
         List<Map<String, String>> expectedGenotypes = new ArrayList<>();
         expectedGenotypes.add(createGenotypeMap("GT", "0|1"));
         expectedGenotypes.add(createGenotypeMap("GT", "1|1"));
         expectedGenotypes.add(createGenotypeMap("GT", "0|0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "2/2"));
         assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
     }
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
@@ -130,7 +130,7 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypes_Allele_Reverse() {
+    public void testGenotypesBiAllelicReverse() {
         //Test allele reverse orientation
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(3173433, Orientation.FORWARD, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
@@ -147,7 +147,7 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypes_Allele_Forward() {
+    public void testGenotypesBiAllelicForward() {
         //Test allele forward orientation
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
@@ -166,7 +166,7 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypes_hyphenated() {
+    public void testGenotypesHyphenated() {
         //Test hyphenated genotypes
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
@@ -179,7 +179,7 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypes_MultiAllelic_Reverse() {
+    public void testGenotypesMultiAllelicReverse() {
         //Test multi-allelic genotypes - reverse orientation
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 null, 23412070L, 23412073L, Orientation.REVERSE,
@@ -194,7 +194,7 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypes_MultiAllelic_Forward() {
+    public void testGenotypesMultiAllelicForward() {
         //Test multi-allelic genotypes - forward orientation
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 null, 23412070L, 23412073L, Orientation.FORWARD,
@@ -210,7 +210,7 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypes_Null_Empty() {
+    public void testGenotypesNullEmpty() {
         //Test genotypes with null and empty values
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 null, 23412070L, 23412073L, Orientation.FORWARD,

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/models/SubSnpCoreFieldsTest.java
@@ -130,72 +130,97 @@ public class SubSnpCoreFieldsTest {
     }
 
     @Test
-    public void testGenotypeList() {
-
+    public void testGenotypes_Allele_Reverse() {
         //Test allele reverse orientation
         SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(3173433, Orientation.FORWARD, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
-                LocusType.SNP, "3", 23412070L, 23412070L,"C", "C",
+                LocusType.SNP, "3", 23412070L, 23412070L, "C", "C",
                 "T", "C/T", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.FORWARD, "NC_003074.8:g.23412070C>T",
                 23412070L, 23412070L, Orientation.FORWARD, "G/G,A/A, G/ A, A |G, ./.", "batch");
-        List<Map<String, String>> expectedGenotypeList = new ArrayList<>();
-        expectedGenotypeList.add(createGenotypeMap("GT", "0/0"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1/1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "0/1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1|0"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "./."));
-        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+        List<Map<String, String>> expectedGenotypes = new ArrayList<>();
+        expectedGenotypes.add(createGenotypeMap("GT", "0/0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "1/1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "0/1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "1|0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "./."));
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
+    }
 
+    @Test
+    public void testGenotypes_Allele_Forward() {
         //Test allele forward orientation
-        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
-                LocusType.SNP, "3", 23412070L, 23412070L,"G", "G",
+                LocusType.SNP, "3", 23412070L, 23412070L, "G", "G",
                 "A", "T/C", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.REVERSE, "NC_003074.8:g.23412070C>T",
                 23412070L, 23412070L, Orientation.REVERSE, "C/T, T/T, C/C, ./., T/C, C, T", "batch");
-        expectedGenotypeList = new ArrayList<>();
-        expectedGenotypeList.add(createGenotypeMap("GT", "0/1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1/1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "0/0"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "./."));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1/0"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "0"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1"));
-        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+        List<Map<String, String>> expectedGenotypes = new ArrayList<>();
+        expectedGenotypes.add(createGenotypeMap("GT", "0/1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "1/1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "0/0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "./."));
+        expectedGenotypes.add(createGenotypeMap("GT", "1/0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "1"));
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
+    }
 
+    @Test
+    public void testGenotypes_hyphenated() {
         //Test hyphenated genotypes
-        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 "NC_003074.8", 23412070L, 23412070L, Orientation.FORWARD,
-                LocusType.SNP, "3", 23412070L, 23412070L,"G", "G",
+                LocusType.SNP, "3", 23412070L, 23412070L, "G", "G",
                 "", "C/-", "NC_003074.8:g.23412070C>T", 23412070L, 23412070L, Orientation.REVERSE, "NC_003074.8:g.23412070C>T",
                 23412070L, 23412070L, Orientation.REVERSE, "-/ - ", "batch");
-        expectedGenotypeList = new ArrayList<>();
-        expectedGenotypeList.add(createGenotypeMap("GT", "1/1"));
-        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+        List<Map<String, String>> expectedGenotypes = new ArrayList<>();
+        expectedGenotypes.add(createGenotypeMap("GT", "1/1"));
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
+    }
 
+    @Test
+    public void testGenotypes_MultiAllelic_Reverse() {
         //Test multi-allelic genotypes - reverse orientation
-        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 null, 23412070L, 23412073L, Orientation.REVERSE,
-                LocusType.SNP, "3", 23412070L, 23412073L,"TAC", "TAC",
+                LocusType.SNP, "3", 23412070L, 23412073L, "TAC", "TAC",
                 "GGC", "GTA/GCC", "", 23412070L, 23412073L, Orientation.FORWARD, "",
                 23412070L, 23412073L, Orientation.FORWARD, "GTA |GCC, GCC|GCC, GTA|GTA", "batch");
-        expectedGenotypeList = new ArrayList<>();
-        expectedGenotypeList.add(createGenotypeMap("GT", "0|1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1|1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "0|0"));
-        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+        List<Map<String, String>> expectedGenotypes = new ArrayList<>();
+        expectedGenotypes.add(createGenotypeMap("GT", "0|1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "1|1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "0|0"));
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
+    }
 
+    @Test
+    public void testGenotypes_MultiAllelic_Forward() {
         //Test multi-allelic genotypes - forward orientation
-        subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
                 null, 23412070L, 23412073L, Orientation.FORWARD,
                 LocusType.SNP, "3", 23412070L, 23412073L,"TAC", "TAC",
                 "GGC", "TAC/GGC/CCT", "", 23412070L, 23412073L, Orientation.FORWARD, "",
                 23412070L, 23412073L, Orientation.FORWARD, "TAC |GGC, GGC|GGC, TAC/TAC, CCT/GGC", "batch");
-        expectedGenotypeList = new ArrayList<>();
-        expectedGenotypeList.add(createGenotypeMap("GT", "0|1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "1|1"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "0/0"));
-        expectedGenotypeList.add(createGenotypeMap("GT", "2/1"));
-        assertEquals(expectedGenotypeList, subSnpCoreFields.getGenotypeList());
+        List<Map<String, String>> expectedGenotypes = new ArrayList<>();
+        expectedGenotypes.add(createGenotypeMap("GT", "0|1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "1|1"));
+        expectedGenotypes.add(createGenotypeMap("GT", "0/0"));
+        expectedGenotypes.add(createGenotypeMap("GT", "2/1"));
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
+    }
+
+    @Test
+    public void testGenotypes_Null_Empty() {
+        //Test genotypes with null and empty values
+        SubSnpCoreFields subSnpCoreFields = new SubSnpCoreFields(492296696, Orientation.REVERSE, 2228714L, Orientation.REVERSE,
+                null, 23412070L, 23412073L, Orientation.FORWARD,
+                LocusType.SNP, "3", 23412070L, 23412073L,"TAC", "TAC",
+                "GGC", "TAC/GGC/CCT", "", 23412070L, 23412073L, Orientation.FORWARD, "",
+                23412070L, 23412073L, Orientation.FORWARD, null, "batch");
+        List<Map<String, String>> expectedGenotypes = new ArrayList<>();
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
+        subSnpCoreFields.setGenotypes("");
+        assertEquals(expectedGenotypes, subSnpCoreFields.getGenotypes());
     }
 
     public static Map<String, String> createGenotypeMap (String key, String value) {


### PR DESCRIPTION
SubSNPCoreFieldReader.java - Included genotype field
SubSNPCoreFields.java - Included genotype field and updated equals/hashcode methods to accomodate this field
SubSnpCoreFieldsToVariantProcessor.java - Add the genotype list as part of the VariantSourceEntry object
