### PR TITLE
Store all samples from a batch

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/SampleReaderConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/SampleReaderConfiguration.java
@@ -46,8 +46,7 @@ public class SampleReaderConfiguration {
         logger.info("Injecting SampleReader with parameters: {}, {}", parameters, dbsnpDatasource);
         DataSource dataSource = dbsnpDatasource.getDatasource();
 
-        SampleReader sampleReader = new SampleReader(parameters.getDbsnpBuild(), parameters.getBatchId(),
-                                                     parameters.getAssembly(), dataSource, parameters.getPageSize());
+        SampleReader sampleReader = new SampleReader(parameters.getBatchId(), dataSource, parameters.getPageSize());
         sampleReader.afterPropertiesSet();
         return new WindingItemStreamReader<>(sampleReader);
     }

--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReader.java
@@ -129,7 +129,8 @@ public class SampleReader extends JdbcCursorItemReader<Sample> {
                         + " WHERE"
                         + "    batch.batch_id = ?"
                         + "    AND ctg.group_term IN (?, ?)"
-                        + "    AND ctg.group_label = ?";
+                        + "    AND ctg.group_label = ?"
+                        + " ORDER BY subind.submitted_ind_id";
         return sql;
     }
 

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/SampleReaderTest.java
@@ -48,8 +48,6 @@ import static org.junit.Assert.assertTrue;
 @ContextConfiguration(classes = {TestConfiguration.class})
 public class SampleReaderTest extends ReaderTest {
 
-    private static final String CHICKEN_ASSEMBLY_5 = "Gallus_gallus-5.0";
-
     private static final int PAGE_SIZE = 2000;
 
     public static final int BATCH_ID = 11825;
@@ -59,8 +57,6 @@ public class SampleReaderTest extends ReaderTest {
     public static final String FIRST_INDIVIDUAL_NAME = "RJF";
 
     public static final String SECOND_INDIVIDUAL_NAME = "BROILER";
-
-    public static final int DBSNP_BUILD = 150;
 
     @Autowired
     private DbsnpTestDatasource dbsnpTestDatasource;
@@ -77,7 +73,7 @@ public class SampleReaderTest extends ReaderTest {
     @Before
     public void setUp() throws Exception {
         dataSource = dbsnpTestDatasource.getDatasource();
-        reader = buildReader(DBSNP_BUILD, BATCH_ID, CHICKEN_ASSEMBLY_5, PAGE_SIZE);
+        reader = buildReader(BATCH_ID, PAGE_SIZE);
 
         Map<String, String> cohorts = new HashMap<>();
         cohorts.put(SampleRowMapper.POPULATION, "RBLS");
@@ -87,8 +83,8 @@ public class SampleReaderTest extends ReaderTest {
         expectedSamples.add(new Sample(BATCH_NAME, SECOND_INDIVIDUAL_NAME, Sex.UNKNOWN_SEX, null, null, cohorts));
     }
 
-    private SampleReader buildReader(int dbsnpBuild, int batch, String assembly, int pageSize) throws Exception {
-        SampleReader fieldsReader = new SampleReader(dbsnpBuild, batch, assembly, dataSource, pageSize);
+    private SampleReader buildReader(int batch, int pageSize) throws Exception {
+        SampleReader fieldsReader = new SampleReader(batch, dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);
@@ -118,7 +114,7 @@ public class SampleReaderTest extends ReaderTest {
     @Test
     public void testQueryWithSeveralPages() throws Exception {
         int pageSize = 1;
-        reader = buildReader(DBSNP_BUILD, BATCH_ID, CHICKEN_ASSEMBLY_5, pageSize);
+        reader = buildReader(BATCH_ID, pageSize);
         List<Sample> list = readAll(reader);
         assertEquals(2, list.size());
         for (Sample sample : list) {
@@ -128,25 +124,9 @@ public class SampleReaderTest extends ReaderTest {
     }
 
     @Test
-    public void testQueryWithDifferentRelease() throws Exception {
-        int dbsnpBuild = 130;
-
-        exception.expect(ItemStreamException.class);
-        buildReader(dbsnpBuild, BATCH_ID, CHICKEN_ASSEMBLY_5, PAGE_SIZE);
-    }
-
-    @Test
-    public void testQueryWithDifferentAssembly() throws Exception {
-        String nonExistingAssembly = "Gallus_gallus-4.0";
-        reader = buildReader(DBSNP_BUILD, BATCH_ID, nonExistingAssembly, PAGE_SIZE);
-        List<Sample> list = readAll(reader);
-        assertEquals(0, list.size());
-    }
-
-    @Test
     public void testQueryWithDifferentBatch() throws Exception {
         int nonExistingBatchId = -1;
-        reader = buildReader(DBSNP_BUILD, nonExistingBatchId, CHICKEN_ASSEMBLY_5, PAGE_SIZE);
+        reader = buildReader(nonExistingBatchId, PAGE_SIZE);
         List<Sample> list = readAll(reader);
         assertEquals(0, list.size());
     }

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/WindingItemReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/WindingItemReaderTest.java
@@ -15,7 +15,6 @@ import uk.ac.ebi.eva.dbsnpimporter.test.DbsnpTestDatasource;
 import uk.ac.ebi.eva.dbsnpimporter.test.configuration.TestConfiguration;
 
 import javax.sql.DataSource;
-import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -25,19 +24,9 @@ import static org.junit.Assert.assertEquals;
 @ContextConfiguration(classes = {TestConfiguration.class})
 public class WindingItemReaderTest {
 
-    private static final String CHICKEN_ASSEMBLY_5 = "Gallus_gallus-5.0";
-
-    private static final String PRIMARY_ASSEMBLY = "Primary_Assembly";
-
     private static final int PAGE_SIZE = 2000;
 
     public static final int BATCH_ID = 11825;
-
-    public static final int FIRST_SUBMITTED_INDIVIDUAL_ID = 6480;
-
-    public static final int SECOND_SUBMITTED_INDIVIDUAL_ID = 6483;
-
-    public static final int DBSNP_BUILD = 150;
 
     private DataSource dataSource;
 
@@ -51,14 +40,12 @@ public class WindingItemReaderTest {
 
     @Test
     public void shouldReadAllSamplesInBatchInSingleOperation() throws Exception {
-        SampleReader reader = buildReader(DBSNP_BUILD, BATCH_ID, CHICKEN_ASSEMBLY_5,
-                                          Collections.singletonList(PRIMARY_ASSEMBLY), PAGE_SIZE);
+        SampleReader reader = buildReader(BATCH_ID, PAGE_SIZE);
         consumeReader(new WindingItemReader<>(reader), 2);
         reader.close();
     }
 
-    private SampleReader buildReader(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
-                                     int pageSize) throws Exception {
+    private SampleReader buildReader(int batch, int pageSize) throws Exception {
         SampleReader fieldsReader = new SampleReader(batch, dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();

--- a/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/WindingItemReaderTest.java
+++ b/dbsnp-importer/src/test/java/uk/ac/ebi/eva/dbsnpimporter/io/readers/WindingItemReaderTest.java
@@ -59,7 +59,7 @@ public class WindingItemReaderTest {
 
     private SampleReader buildReader(int dbsnpBuild, int batch, String assembly, List<String> assemblyTypes,
                                      int pageSize) throws Exception {
-        SampleReader fieldsReader = new SampleReader(dbsnpBuild, batch, assembly, dataSource, pageSize);
+        SampleReader fieldsReader = new SampleReader(batch, dataSource, pageSize);
         fieldsReader.afterPropertiesSet();
         ExecutionContext executionContext = new ExecutionContext();
         fieldsReader.open(executionContext);


### PR DESCRIPTION
The number of samples in `VariantSource` and `VariantSourceEntry` objects must match.

Because dbSNP don't store missing genotypes, the list of samples retrieved for a given ss ID could be smaller than the total number of those in the batch. When the genotypes are populated in the `variants` collection, this mismatch causes the web services to break.

This PR removes the query on a specific ss ID from the batch to solve the issue.