### PR TITLE
Avoided exception in 'afterWrite' listener method

### DIFF
--- a/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ListenersConfiguration.java
+++ b/dbsnp-importer/src/main/java/uk/ac/ebi/eva/dbsnpimporter/configuration/ListenersConfiguration.java
@@ -91,9 +91,13 @@ public class ListenersConfiguration {
 
         @Override
         public void afterWrite(List<? extends IVariant> items) {
-            IVariant lastItem = items.get(items.size() - 1);
-            logger.debug("Written chunk of {} items. Last item was {}: {}", items.size(), lastItem.getMainId(),
-                         lastItem);
+            if (items.size() > 0) {
+                IVariant lastItem = items.get(items.size() - 1);
+                logger.debug("Written chunk of {} items. Last item was {}: {}", items.size(), lastItem.getMainId(),
+                        lastItem);
+            } else {
+                logger.debug("Written chunk of 0 items.");
+            }
         }
 
         @Override
@@ -158,9 +162,13 @@ public class ListenersConfiguration {
 
         @Override
         public void afterWrite(List<? extends IVariantSource> items) {
-            IVariantSource lastItem = items.get(items.size() - 1);
-            logger.debug("Written chunk of {} items. Last item was {}: {}", items.size(), lastItem.getStudyId(),
-                         lastItem);
+            if (items.size() > 0) {
+                IVariantSource lastItem = items.get(items.size() - 1);
+                logger.debug("Written chunk of {} items. Last item was {}: {}", items.size(), lastItem.getStudyId(),
+                             lastItem);
+            } else {
+                logger.debug("Written chunk of 0 items.");
+            }
         }
 
         @Override


### PR DESCRIPTION
The `afterWrite` listener method throws an exception if no items were written, because it tries to access index -1. This is unusual, but it can happen for example if all the variants in a chunk belong to the same contig and that can't be found in the FASTA sequence.