### PR TITLE
EVA-1113 VCF dumper staging deployment

### DIFF
--- a/vcf-dumper/vcf-dumper-lib/pom.xml
+++ b/vcf-dumper/vcf-dumper-lib/pom.xml
@@ -52,20 +52,6 @@
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>repackage</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <layout>NONE</layout>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
We had an issue with plain `mvn clean install` compilations. I tracked down the error to the spring-boot-maven-plugin used in vcf-dumper-lib.

IMO that plugin would only be useful in vcf-dumper-ws.

As a side note, I thought at the beginning that this was caused by overwriting the package uk.ac.ebi.eva.vcfdump in several modules, which turned out irrelevant. I didn't do the refactoring for that in this PR, but it would be cleaner if we did it as well at some point.