### PR TITLE
EVA-1549 Test APIs and pipelines using RedHat-supported JDK 8 - bug: annotation depends on read preference

### DIFF
--- a/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VariantToVariantContextConverter.java
+++ b/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VariantToVariantContextConverter.java
@@ -49,8 +49,6 @@ public class VariantToVariantContextConverter {
 
     public static final String ANNOTATION_KEY = "CSQ";
 
-    private final VariantContextBuilder variantContextBuilder;
-
     private List<VariantSource> sources;
 
     private Set<String> studies;
@@ -72,7 +70,6 @@ public class VariantToVariantContextConverter {
             this.studies = sources.stream().map(VariantSource::getStudyId).collect(Collectors.toSet());
         }
         this.filesSampleNamesEquivalences = filesSampleNamesEquivalences;
-        variantContextBuilder = new VariantContextBuilder();
     }
 
     public VariantContext transform(VariantWithSamplesAndAnnotation variant) {
@@ -84,6 +81,9 @@ public class VariantToVariantContextConverter {
         String[] allelesArray = getAllelesArray(variant);
 
         Set<Genotype> genotypes = getGenotypes(variant, allelesArray);
+
+        // don't reuse instances of this builder. It carries over state from one variant to the next one
+        VariantContextBuilder variantContextBuilder = new VariantContextBuilder();
 
         if (!excludeAnnotations) {
             String csq = getAnnotationAttributes(variant);
@@ -100,6 +100,7 @@ public class VariantToVariantContextConverter {
                 .alleles(allelesArray)
                 .unfiltered()
                 .genotypes(genotypes).make();
+
         return variantContext;
     }
 

--- a/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VariantToVariantContextConverter.java
+++ b/vcf-dumper/vcf-dumper-lib/src/main/java/uk/ac/ebi/eva/vcfdump/VariantToVariantContextConverter.java
@@ -208,12 +208,14 @@ public class VariantToVariantContextConverter {
                                                              contextNucleotide + variant.getReference(),
                                                              contextNucleotide + variant.getAlternate());
             newVariant.addSourceEntries(variant.getSourceEntries());
+            newVariant.setAnnotation(variant.getAnnotation());
         } else {
             // update variant end
             newVariant = new VariantWithSamplesAndAnnotation(variant.getChromosome(), variant.getStart(), variant.getEnd() + 1,
                                                              variant.getReference() + contextNucleotide,
                                                              variant.getAlternate() + contextNucleotide);
             newVariant.addSourceEntries(variant.getSourceEntries());
+            newVariant.setAnnotation(variant.getAnnotation());
         }
         return newVariant;
     }


### PR DESCRIPTION
2 bugs:
- VariantContextBuilder was reusing state across built objects. changing the read preference changes the order of the results, which changes the reused state. Once the state is not reused, the order doesn't matter.
- when a context base is added, the annotation was lost