### PR TITLE
EVA-2962 - Add clustering QC job to remapping automation

### DIFF
--- a/variant-remapping-automation/remapping_automation.py
+++ b/variant-remapping-automation/remapping_automation.py
@@ -227,6 +227,7 @@ eva.count-stats.password={counts_password}
             'genome_assembly_dir': cfg['genome_downloader']['output_directory'],
             'template_properties': self.write_remapping_process_props_template(prop_template_file),
             'clustering_template_properties': self.write_clustering_props_template(clustering_template_file, instance),
+            'clustering_instance': instance,
             'remapping_config': cfg.config_file
         }
 

--- a/variant-remapping-automation/remapping_process.nf
+++ b/variant-remapping-automation/remapping_process.nf
@@ -232,7 +232,7 @@ process cluster_studies_from_mongo {
     output:
     path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties" into clustering_props
     path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.log" into clustering_log_filename
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_rs_report.txt" into rs_report
+    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_rs_report.txt" into rs_report_filename
 
     publishDir "$params.output_dir/properties", overwrite: true, mode: "copy", pattern: "*.properties"
     publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
@@ -259,7 +259,7 @@ process qc_clustering {
     path rs_report from rs_report_filename
 
     output:
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties" into clustering_qc_props_filename
+    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties" into clustering_qc_props
     path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.log" into clustering_qc_log_filename
 
     publishDir "$params.output_dir/properties", overwrite: true, mode: "copy", pattern: "*.properties"

--- a/variant-remapping-automation/remapping_process.nf
+++ b/variant-remapping-automation/remapping_process.nf
@@ -39,6 +39,7 @@ if (!params.taxonomy_id || !params.source_assembly_accession || !params.target_a
 }
 
 species_name = params.species_name.toLowerCase().replace(" ", "_")
+source_to_target = "${params.source_assembly_accession}_to_${params.target_assembly_accession}"
 
 
 process retrieve_source_genome {
@@ -230,23 +231,23 @@ process cluster_studies_from_mongo {
     path ingestion_log from ingestion_log_filename
 
     output:
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties" into clustering_props
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.log" into clustering_log_filename
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_rs_report.txt" into rs_report_filename
+    path "${source_to_target}_clustering.properties" into clustering_props
+    path "${source_to_target}_clustering.log" into clustering_log_filename
+    path "${source_to_target}_rs_report.txt" into rs_report_filename
 
     publishDir "$params.output_dir/properties", overwrite: true, mode: "copy", pattern: "*.properties"
     publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
 
     """
-    cat ${params.template_properties} ${params.clustering_template_properties} > ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
-    echo "parameters.projectAccession=" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
-    echo "parameters.projects=${params.studies}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
-    echo "spring.batch.job.names=STUDY_CLUSTERING_JOB" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
-    echo "parameters.assemblyAccession=${params.target_assembly_accession}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
-    echo "parameters.remappedFrom=${params.source_assembly_accession}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
-    echo "parameters.rsReportPath=${params.source_assembly_accession}_to_${params.target_assembly_accession}_rs_report.txt" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.properties
+    cat ${params.template_properties} ${params.clustering_template_properties} > ${source_to_target}_clustering.properties
+    echo "parameters.projectAccession=" >> ${source_to_target}_clustering.properties
+    echo "parameters.projects=${params.studies}" >> ${source_to_target}_clustering.properties
+    echo "spring.batch.job.names=STUDY_CLUSTERING_JOB" >> ${source_to_target}_clustering.properties
+    echo "parameters.assemblyAccession=${params.target_assembly_accession}" >> ${source_to_target}_clustering.properties
+    echo "parameters.remappedFrom=${params.source_assembly_accession}" >> ${source_to_target}_clustering.properties
+    echo "parameters.rsReportPath=${source_to_target}_rs_report.txt" >> ${source_to_target}_clustering.properties
 
-    java -jar $params.jar.study_clustering --spring.config.name=${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering > ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering.log
+    java -jar $params.jar.study_clustering --spring.config.name=${source_to_target}_clustering > ${source_to_target}_clustering.log
     """
 }
 
@@ -259,21 +260,21 @@ process qc_clustering {
     path rs_report from rs_report_filename
 
     output:
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties" into clustering_qc_props
-    path "${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.log" into clustering_qc_log_filename
+    path "${source_to_target}_clustering_qc.properties" into clustering_qc_props
+    path "${source_to_target}_clustering_qc.log" into clustering_qc_log_filename
 
     publishDir "$params.output_dir/properties", overwrite: true, mode: "copy", pattern: "*.properties"
     publishDir "$params.output_dir/logs", overwrite: true, mode: "copy", pattern: "*.log*"
 
     """
-    cat ${params.template_properties} ${params.clustering_template_properties} > ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
-    echo "parameters.projectAccession=" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
-    echo "parameters.projects=${params.studies}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
-    echo "spring.batch.job.names=NEW_CLUSTERED_VARIANTS_QC_JOB" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
-    echo "parameters.assemblyAccession=${params.target_assembly_accession}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
-    echo "parameters.remappedFrom=${params.source_assembly_accession}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
-    echo "parameters.rsReportPath=${rs_report}" >> ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.properties
+    cat ${params.template_properties} ${params.clustering_template_properties} > ${source_to_target}_clustering_qc.properties
+    echo "parameters.projectAccession=" >> ${source_to_target}_clustering_qc.properties
+    echo "parameters.projects=${params.studies}" >> ${source_to_target}_clustering_qc.properties
+    echo "spring.batch.job.names=NEW_CLUSTERED_VARIANTS_QC_JOB" >> ${source_to_target}_clustering_qc.properties
+    echo "parameters.assemblyAccession=${params.target_assembly_accession}" >> ${source_to_target}_clustering_qc.properties
+    echo "parameters.remappedFrom=${params.source_assembly_accession}" >> ${source_to_target}_clustering_qc.properties
+    echo "parameters.rsReportPath=${rs_report}" >> ${source_to_target}_clustering_qc.properties
 
-    java -jar $params.jar.study_clustering --spring.config.name=${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc > ${params.source_assembly_accession}_to_${params.target_assembly_accession}_clustering_qc.log
+    java -jar $params.jar.study_clustering --spring.config.name=${source_to_target}_clustering_qc > ${source_to_target}_clustering_qc.log
 """
 }


### PR DESCRIPTION
Also few other fixes to the automation, to ensure that clustering is executed on the specified instance and log files don't get overwritten when multiple source assemblies are remapped to a single target.