### PR TITLE
EVA-2988 - Make custom assembly renaming optional

### DIFF
--- a/variant-remapping-automation/get_custom_assembly.py
+++ b/variant-remapping-automation/get_custom_assembly.py
@@ -157,8 +157,9 @@ class CustomAssembly(AppLogger):
         for name in self.contig_names_in_fasta:
             if name not in genbank_contigs:
                 if name not in map_to_genbank:
-                    raise ValueError(f'Sequence {name} in fasta file does not match any INSDC sequence')
-                rename_map[name] = map_to_genbank[name]
+                    self.error(f'Sequence {name} in fasta file does not match any INSDC sequence')
+                else:
+                    rename_map[name] = map_to_genbank[name]
 
         return rename_map
 


### PR DESCRIPTION
Happy to discuss this but considering it caused a lot of failure I'm wondering if crashing when the renaming failed is the best idea.