### PR TITLE
EVA-3689: Increase connectTimeoutMS for mongoexport

### DIFF
--- a/accession-monitoring/__init__.py
+++ b/accession-monitoring/__init__.py
@@ -16,7 +16,6 @@
 
 import configparser
 import logging
-import os
 import subprocess
 import sys
 
@@ -56,7 +55,6 @@ def run_command_with_output(command_description, command, return_process_output=
     process_output = ""
 
     logger.info("Starting process: " + command_description)
-    logger.info("Running command: " + command)
 
     with subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=1, universal_newlines=True,
                           shell=True) as process:

--- a/accession-monitoring/monitor_duplicate_accessions.py
+++ b/accession-monitoring/monitor_duplicate_accessions.py
@@ -14,20 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import click
-from datetime import datetime
 import getpass
+import os
 import smtplib
-from __init__ import *
+from datetime import datetime
 from urllib.parse import quote_plus
 
+import click
 
-def get_mongo_uri(mongo_connection_properties):
-    return "mongodb://{0}:{1}@{2}/{3}?authSource={4}".format(mongo_connection_properties["mongo_username"],
-                                                             quote_plus(mongo_connection_properties["mongo_password"]),
-                                                             mongo_connection_properties["mongo_host"],
-                                                             mongo_connection_properties["mongo_db"],
-                                                             mongo_connection_properties["mongo_auth_db"])
+from __init__ import *
+
+
+def get_mongo_uri(mongo_connection_properties, timeout=60000):
+    return "mongodb://{0}:{1}@{2}/{3}?authSource={4}&connectTimeoutMS={5}".format(
+        mongo_connection_properties["mongo_username"],
+        quote_plus(mongo_connection_properties["mongo_password"]),
+        mongo_connection_properties["mongo_host"],
+        mongo_connection_properties["mongo_db"],
+        mongo_connection_properties["mongo_auth_db"],
+        timeout
+    )
 
 
 def export_mongo_accessions(mongo_connection_properties, collection_name, export_output_filename):

--- a/accession-monitoring/monitor_duplicate_accessions.py
+++ b/accession-monitoring/monitor_duplicate_accessions.py
@@ -37,7 +37,7 @@ def get_mongo_uri(mongo_connection_properties, timeout=60000):
 
 
 def export_mongo_accessions(mongo_connection_properties, collection_name, export_output_filename):
-    export_command = 'mongoexport --uri {0} ' \
+    export_command = 'mongoexport --uri "{0}" ' \
                      '--collection {1} --type=csv --fields accession ' \
                      "--query  '{{\"remappedFrom\": {{\"$exists\": false}}}}' " \
                      '-o "{2}" 2>&1' \


### PR DESCRIPTION
See documentation [here](https://www.mongodb.com/docs/manual/tutorial/connection-pool-performance-tuning/) and specific to mongoexport (which uses the Go driver) [here](https://www.mongodb.com/docs/drivers/go/current/fundamentals/connections/connection-guide/#std-label-golang-connection-options).

I also removed the logging of the export command, as it shows the password in cleartext. It's convenient for debugging but for security reasons I think we'd better do without.